### PR TITLE
fix typo in atom.gyp

### DIFF
--- a/atom.gyp
+++ b/atom.gyp
@@ -850,7 +850,7 @@
               'postbuild_name': 'Add symlinks for framework subdirectories',
               'action': [
                 'tools/mac/create-framework-subdir-symlinks.sh',
-                '<(project_name) Framework',
+                '<(product_name) Framework',
                 'Libraries',
                 'Frameworks',
               ],


### PR DESCRIPTION
use product_name instead of project_name when creating framework symlinks; fixes build on MacOS