### PR TITLE
Add webFrame.registerUrlSchemeAsSecure API

### DIFF
--- a/atom.gyp
+++ b/atom.gyp
@@ -550,6 +550,8 @@
         'vendor/brightray/vendor/download/libchromiumcontent/src/v8/include',
         # The `node.h` is using `#include"ares.h"`.
         'vendor/node/deps/cares/include',
+        # The `third_party/WebKit/Source/platform/weborigin/SchemeRegistry.h` is using `platform/PlatformExport.h`.
+        'vendor/brightray/vendor/download/libchromiumcontent/src/third_party/WebKit/Source',
       ],
       'direct_dependent_settings': {
         'include_dirs': [

--- a/atom/browser/atom_browser_client.cc
+++ b/atom/browser/atom_browser_client.cc
@@ -87,8 +87,8 @@ void AtomBrowserClient::OverrideWebkitPrefs(
   prefs->allow_universal_access_from_file_urls = true;
   prefs->allow_file_access_from_file_urls = true;
   prefs->experimental_webgl_enabled = true;
-  prefs->allow_displaying_insecure_content = true;
-  prefs->allow_running_insecure_content = true;
+  prefs->allow_displaying_insecure_content = false;
+  prefs->allow_running_insecure_content = false;
 
   // Turn off web security for devtools.
   if (url.SchemeIs("chrome-devtools")) {

--- a/atom/common/node_includes.h
+++ b/atom/common/node_includes.h
@@ -7,6 +7,7 @@
 
 // Include common headers for using node APIs.
 
+#undef ASSERT
 #undef CHECK
 #undef CHECK_EQ
 #undef CHECK_NE
@@ -15,6 +16,7 @@
 #undef CHECK_LE
 #undef CHECK_LT
 #undef DISALLOW_COPY_AND_ASSIGN
+#undef NO_RETURN
 #undef debug_string  // This is defined in OS X 10.9 SDK in AssertMacros.h.
 #include "vendor/node/src/env.h"
 #include "vendor/node/src/env-inl.h"

--- a/atom/renderer/api/atom_api_web_frame.cc
+++ b/atom/renderer/api/atom_api_web_frame.cc
@@ -5,9 +5,9 @@
 #include "atom/renderer/api/atom_api_web_frame.h"
 
 // This defines are required by SchemeRegistry.h.
-#define OS(WTF_FEATURE) (defined WTF_OS_##WTF_FEATURE  && WTF_OS_##WTF_FEATURE)
-#define USE(WTF_FEATURE) (defined WTF_USE_##WTF_FEATURE  && WTF_USE_##WTF_FEATURE)
-#define ENABLE(WTF_FEATURE) (defined ENABLE_##WTF_FEATURE  && ENABLE_##WTF_FEATURE)
+#define OS(WTF_FEATURE) (defined WTF_OS_##WTF_FEATURE  && WTF_OS_##WTF_FEATURE)  // NOLINT
+#define USE(WTF_FEATURE) (defined WTF_USE_##WTF_FEATURE  && WTF_USE_##WTF_FEATURE)  // NOLINT
+#define ENABLE(WTF_FEATURE) (defined ENABLE_##WTF_FEATURE  && ENABLE_##WTF_FEATURE)  // NOLINT
 
 #include "atom/common/native_mate_converters/string16_converter.h"
 #include "atom/renderer/api/atom_api_spell_check_client.h"

--- a/atom/renderer/api/atom_api_web_frame.cc
+++ b/atom/renderer/api/atom_api_web_frame.cc
@@ -4,6 +4,11 @@
 
 #include "atom/renderer/api/atom_api_web_frame.h"
 
+// This defines are required by SchemeRegistry.h.
+#define OS(WTF_FEATURE) (defined WTF_OS_##WTF_FEATURE  && WTF_OS_##WTF_FEATURE)
+#define USE(WTF_FEATURE) (defined WTF_USE_##WTF_FEATURE  && WTF_USE_##WTF_FEATURE)
+#define ENABLE(WTF_FEATURE) (defined ENABLE_##WTF_FEATURE  && ENABLE_##WTF_FEATURE)
+
 #include "atom/common/native_mate_converters/string16_converter.h"
 #include "atom/renderer/api/atom_api_spell_check_client.h"
 #include "content/public/renderer/render_frame.h"
@@ -12,8 +17,27 @@
 #include "third_party/WebKit/public/web/WebDocument.h"
 #include "third_party/WebKit/public/web/WebLocalFrame.h"
 #include "third_party/WebKit/public/web/WebView.h"
+#include "third_party/WebKit/Source/platform/weborigin/SchemeRegistry.h"
 
 #include "atom/common/node_includes.h"
+
+namespace mate {
+
+template<>
+struct Converter<WTF::String> {
+  static bool FromV8(v8::Isolate* isolate,
+                     v8::Handle<v8::Value> val,
+                     WTF::String* out) {
+    if (!val->IsString())
+      return false;
+
+    v8::String::Value s(val);
+    *out = WTF::String(reinterpret_cast<const base::char16*>(*s), s.length());
+    return true;
+  }
+};
+
+}  // namespace mate
 
 namespace atom {
 
@@ -82,7 +106,9 @@ mate::ObjectTemplateBuilder WebFrame::GetObjectTemplateBuilder(
       .SetMethod("registerEmbedderCustomElement",
                  &WebFrame::RegisterEmbedderCustomElement)
       .SetMethod("attachGuest", &WebFrame::AttachGuest)
-      .SetMethod("setSpellCheckProvider", &WebFrame::SetSpellCheckProvider);
+      .SetMethod("setSpellCheckProvider", &WebFrame::SetSpellCheckProvider)
+      .SetMethod("registerUrlSchemeAsSecure",
+                 &blink::SchemeRegistry::registerURLSchemeAsSecure);
 }
 
 // static

--- a/docs/api/chrome-command-line-switches.md
+++ b/docs/api/chrome-command-line-switches.md
@@ -57,3 +57,7 @@ Like `--host-rules` but these `rules` only apply to the host resolver.
 [app]: app.md
 [append-switch]: app.md#appcommandlineappendswitchswitch-value
 [ready]: app.md#event-ready
+
+## --ignore-certificate-errors
+
+Ignore certificate related errors.

--- a/docs/api/web-frame.md
+++ b/docs/api/web-frame.md
@@ -53,4 +53,14 @@ require('web-frame').setSpellCheckProvider("en-US", true, {
 });
 ```
 
+## webFrame.registerUrlSchemeAsSecure(scheme)
+
+* `scheme` String
+
+Sets the `scheme` as secure scheme.
+
+Secure schemes do not trigger mixed content warnings. For example, `https` and
+`data` are secure schemes because they cannot be corrupted by active network
+attackers.
+
 [spellchecker]: https://github.com/atom/node-spellchecker

--- a/script/lib/config.py
+++ b/script/lib/config.py
@@ -4,7 +4,7 @@ import platform
 import sys
 
 BASE_URL = 'http://gh-contractor-zcbenz.s3.amazonaws.com/libchromiumcontent'
-LIBCHROMIUMCONTENT_COMMIT = '55efd338101e08691560192b2be0f9c3b1b0eb72'
+LIBCHROMIUMCONTENT_COMMIT = 'fba5addae75d944d62a8bd5f4fd23c2929405c83'
 
 ARCH = {
     'cygwin': '32bit',


### PR DESCRIPTION
```markdown
## webFrame.registerUrlSchemeAsSecure(scheme)

* `scheme` String

Sets the `scheme` as secure scheme.

Secure schemes do not trigger mixed content warnings. For example, `https` and
`data` are secure schemes because they cannot be corrupted by active network
attackers.
```

Fixes #971.