### PR TITLE
Remove libgcrypt.so from shipped system libraries

### DIFF
--- a/script/create-dist.py
+++ b/script/create-dist.py
@@ -72,7 +72,6 @@ TARGET_DIRECTORIES = {
 
 SYSTEM_LIBRARIES = [
   'libudev.so',
-  'libgcrypt.so',
   'libnotify.so',
 ]
 


### PR DESCRIPTION
Looks like libgcrypt.so is not used anymore, so there is no need to ship it. I cannot point out though when/why this dependency was dropped, so please double-check.