### PR TITLE
Convert arguments to V8 directly in EventEmitter::Emit

### DIFF
--- a/atom/browser/api/atom_api_app.cc
+++ b/atom/browser/api/atom_api_app.cc
@@ -12,7 +12,6 @@
 #include "atom/browser/browser.h"
 #include "atom/common/native_mate_converters/file_path_converter.h"
 #include "atom/common/native_mate_converters/gurl_converter.h"
-#include "base/values.h"
 #include "base/command_line.h"
 #include "base/environment.h"
 #include "base/files/file_path.h"
@@ -124,15 +123,11 @@ void App::OnQuit() {
 }
 
 void App::OnOpenFile(bool* prevent_default, const std::string& file_path) {
-  base::ListValue args;
-  args.AppendString(file_path);
-  *prevent_default = Emit("open-file", args);
+  *prevent_default = Emit("open-file", file_path);
 }
 
 void App::OnOpenURL(const std::string& url) {
-  base::ListValue args;
-  args.AppendString(url);
-  Emit("open-url", args);
+  Emit("open-url", url);
 }
 
 void App::OnActivateWithNoOpenWindows() {

--- a/atom/browser/api/atom_api_auto_updater.cc
+++ b/atom/browser/api/atom_api_auto_updater.cc
@@ -5,7 +5,6 @@
 #include "atom/browser/api/atom_api_auto_updater.h"
 
 #include "base/time/time.h"
-#include "base/values.h"
 #include "atom/browser/auto_updater.h"
 #include "atom/browser/browser.h"
 #include "native_mate/dictionary.h"
@@ -26,9 +25,7 @@ AutoUpdater::~AutoUpdater() {
 }
 
 void AutoUpdater::OnError(const std::string& error) {
-  base::ListValue args;
-  args.AppendString(error);
-  Emit("error", args);
+  Emit("error", error);
 }
 
 void AutoUpdater::OnCheckingForUpdate() {
@@ -49,13 +46,8 @@ void AutoUpdater::OnUpdateDownloaded(const std::string& release_notes,
                                      const std::string& update_url,
                                      const base::Closure& quit_and_install) {
   quit_and_install_ = quit_and_install;
-
-  base::ListValue args;
-  args.AppendString(release_notes);
-  args.AppendString(release_name);
-  args.AppendDouble(release_date.ToJsTime());
-  args.AppendString(update_url);
-  Emit("update-downloaded-raw", args);
+  Emit("update-downloaded-raw", release_notes, release_name,
+       release_date.ToJsTime(), update_url);
 }
 
 mate::ObjectTemplateBuilder AutoUpdater::GetObjectTemplateBuilder(

--- a/atom/browser/api/atom_api_protocol.cc
+++ b/atom/browser/api/atom_api_protocol.cc
@@ -305,9 +305,7 @@ void Protocol::UninterceptProtocolInIO(const std::string& scheme) {
 
 void Protocol::EmitEventInUI(const std::string& event,
                              const std::string& parameter) {
-  base::ListValue args;
-  args.AppendString(parameter);
-  Emit(event, args);
+  Emit(event, parameter);
 }
 
 // static

--- a/atom/browser/api/atom_api_window.cc
+++ b/atom/browser/api/atom_api_window.cc
@@ -8,6 +8,8 @@
 #include "atom/browser/browser.h"
 #include "atom/browser/native_window.h"
 #include "atom/common/native_mate_converters/gfx_converter.h"
+#include "atom/common/native_mate_converters/gurl_converter.h"
+#include "atom/common/native_mate_converters/string16_converter.h"
 #include "content/public/browser/render_process_host.h"
 #include "native_mate/callback.h"
 #include "native_mate/constructor.h"
@@ -76,26 +78,18 @@ Window::~Window() {
 
 void Window::OnPageTitleUpdated(bool* prevent_default,
                                 const std::string& title) {
-  base::ListValue args;
-  args.AppendString(title);
-  *prevent_default = Emit("page-title-updated", args);
+  *prevent_default = Emit("page-title-updated", title);
 }
 
 void Window::WillCreatePopupWindow(const base::string16& frame_name,
                                    const GURL& target_url,
                                    const std::string& partition_id,
                                    WindowOpenDisposition disposition) {
-  base::ListValue args;
-  args.AppendString(target_url.spec());
-  args.AppendString(frame_name);
-  args.AppendInteger(disposition);
-  Emit("-new-window", args);
+  Emit("-new-window", target_url, frame_name, static_cast<int>(disposition));
 }
 
 void Window::WillNavigate(bool* prevent_default, const GURL& url) {
-  base::ListValue args;
-  args.AppendString(url.spec());
-  *prevent_default = Emit("-will-navigate", args);
+  *prevent_default = Emit("-will-navigate", url);
 }
 
 void Window::WillCloseWindow(bool* prevent_default) {

--- a/atom/browser/api/event_emitter.cc
+++ b/atom/browser/api/event_emitter.cc
@@ -5,9 +5,6 @@
 #include "atom/browser/api/event_emitter.h"
 
 #include "atom/browser/api/event.h"
-#include "atom/common/native_mate_converters/v8_value_converter.h"
-#include "base/memory/scoped_ptr.h"
-#include "base/values.h"
 #include "native_mate/arguments.h"
 #include "native_mate/object_template_builder.h"
 
@@ -41,43 +38,11 @@ v8::Local<v8::Object> CreateEventObject(v8::Isolate* isolate) {
 EventEmitter::EventEmitter() {
 }
 
-bool EventEmitter::Emit(const base::StringPiece& name) {
-  return Emit(name, base::ListValue());
-}
-
-bool EventEmitter::Emit(const base::StringPiece& name,
-                        const base::ListValue& args) {
-  return Emit(name, args, NULL, NULL);
-}
-
-bool EventEmitter::Emit(const base::StringPiece& name,
-                        const base::ListValue& args,
-                        content::WebContents* sender,
-                        IPC::Message* message) {
-  v8::Isolate* isolate = v8::Isolate::GetCurrent();
-  v8::Locker locker(isolate);
-  v8::HandleScope handle_scope(isolate);
-
-  v8::Handle<v8::Context> context = isolate->GetCurrentContext();
-  scoped_ptr<atom::V8ValueConverter> converter(new atom::V8ValueConverter);
-
-  // v8_args = [args...];
-  Arguments v8_args;
-  v8_args.reserve(args.GetSize());
-  for (size_t i = 0; i < args.GetSize(); i++) {
-    const base::Value* value(NULL);
-    if (args.Get(i, &value))
-      v8_args.push_back(converter->ToV8Value(value, context));
-  }
-
-  return Emit(isolate, name, v8_args, sender, message);
-}
-
-bool EventEmitter::Emit(v8::Isolate* isolate,
-                        const base::StringPiece& name,
-                        Arguments args,
-                        content::WebContents* sender,
-                        IPC::Message* message) {
+bool EventEmitter::CallEmit(v8::Isolate* isolate,
+                            const base::StringPiece& name,
+                            content::WebContents* sender,
+                            IPC::Message* message,
+                            ValueArray args) {
   v8::Handle<v8::Object> event;
   bool use_native_event = sender && message;
 

--- a/atom/browser/api/event_emitter.h
+++ b/atom/browser/api/event_emitter.h
@@ -9,10 +9,6 @@
 
 #include "native_mate/wrappable.h"
 
-namespace base {
-class ListValue;
-}
-
 namespace content {
 class WebContents;
 }
@@ -26,29 +22,39 @@ namespace mate {
 // Provide helperers to emit event in JavaScript.
 class EventEmitter : public Wrappable {
  public:
-  typedef std::vector<v8::Handle<v8::Value>> Arguments;
+  typedef std::vector<v8::Handle<v8::Value>> ValueArray;
 
  protected:
   EventEmitter();
 
-  // this.emit(name, new Event());
-  bool Emit(const base::StringPiece& name);
-
   // this.emit(name, new Event(), args...);
-  bool Emit(const base::StringPiece& name, const base::ListValue& args);
+  template<typename... Args>
+  bool Emit(const base::StringPiece& name, const Args&... args) {
+    return EmitWithSender(name, nullptr, nullptr, args...);
+  }
 
   // this.emit(name, new Event(sender, message), args...);
-  bool Emit(const base::StringPiece& name, const base::ListValue& args,
-            content::WebContents* sender, IPC::Message* message);
+  template<typename... Args>
+  bool EmitWithSender(const base::StringPiece& name,
+                      content::WebContents* sender,
+                      IPC::Message* message,
+                      const Args&... args) {
+    v8::Isolate* isolate = v8::Isolate::GetCurrent();
+    v8::Locker locker(isolate);
+    v8::HandleScope handle_scope(isolate);
 
-  // Lower level implementations.
-  bool Emit(v8::Isolate* isolate,
-            const base::StringPiece& name,
-            Arguments args,
-            content::WebContents* sender = nullptr,
-            IPC::Message* message = nullptr);
+    ValueArray converted = { ConvertToV8(isolate, args)... };
+    return CallEmit(isolate, name, sender, message, converted);
+  }
 
  private:
+  // Lower level implementations.
+  bool CallEmit(v8::Isolate* isolate,
+                const base::StringPiece& name,
+                content::WebContents* sender,
+                IPC::Message* message,
+                ValueArray args);
+
   DISALLOW_COPY_AND_ASSIGN(EventEmitter);
 };
 

--- a/atom/browser/api/lib/web-contents.coffee
+++ b/atom/browser/api/lib/web-contents.coffee
@@ -48,10 +48,12 @@ module.exports.wrap = (webContents) ->
     process.emit 'ATOM_BROWSER_RELEASE_RENDER_VIEW', "#{processId}-#{routingId}"
 
   # Dispatch IPC messages to the ipc module.
-  webContents.on 'ipc-message', (event, channel, args...) ->
+  webContents.on 'ipc-message', (event, packed) ->
+    [channel, args...] = packed
     Object.defineProperty event, 'sender', value: webContents
     ipc.emit channel, event, args...
-  webContents.on 'ipc-message-sync', (event, channel, args...) ->
+  webContents.on 'ipc-message-sync', (event, packed) ->
+    [channel, args...] = packed
     Object.defineProperty event, 'returnValue', set: (value) -> event.sendReply JSON.stringify(value)
     Object.defineProperty event, 'sender', value: webContents
     ipc.emit channel, event, args...

--- a/atom/browser/lib/guest-view-manager.coffee
+++ b/atom/browser/lib/guest-view-manager.coffee
@@ -68,7 +68,8 @@ createGuest = (embedder, params) ->
         embedder.send "ATOM_SHELL_GUEST_VIEW_INTERNAL_DISPATCH_EVENT-#{guest.viewInstanceId}", event, args...
 
   # Dispatch guest's IPC messages to embedder.
-  guest.on 'ipc-message-host', (_, channel, args...) ->
+  guest.on 'ipc-message-host', (_, packed) ->
+    [channel, args...] = packed
     embedder.send "ATOM_SHELL_GUEST_VIEW_INTERNAL_IPC_MESSAGE-#{guest.viewInstanceId}", channel, args...
 
   # Autosize.

--- a/atom/common/native_mate_converters/value_converter.cc
+++ b/atom/common/native_mate_converters/value_converter.cc
@@ -40,7 +40,8 @@ bool Converter<base::ListValue>::FromV8(v8::Isolate* isolate,
 v8::Handle<v8::Value> Converter<base::ListValue>::ToV8(
     v8::Isolate* isolate,
     const base::ListValue& val) {
-  return v8::Undefined(isolate);
+  scoped_ptr<atom::V8ValueConverter> converter(new atom::V8ValueConverter);
+  return converter->ToV8Value(&val, isolate->GetCurrentContext());
 }
 
 }  // namespace mate

--- a/atom/common/native_mate_converters/value_converter.cc
+++ b/atom/common/native_mate_converters/value_converter.cc
@@ -37,4 +37,10 @@ bool Converter<base::ListValue>::FromV8(v8::Isolate* isolate,
   }
 }
 
+v8::Handle<v8::Value> Converter<base::ListValue>::ToV8(
+    v8::Isolate* isolate,
+    const base::ListValue& val) {
+  return v8::Undefined(isolate);
+}
+
 }  // namespace mate

--- a/atom/common/native_mate_converters/value_converter.h
+++ b/atom/common/native_mate_converters/value_converter.h
@@ -26,6 +26,8 @@ struct Converter<base::ListValue> {
   static bool FromV8(v8::Isolate* isolate,
                      v8::Handle<v8::Value> val,
                      base::ListValue* out);
+  static v8::Handle<v8::Value> ToV8(v8::Isolate* isolate,
+                                    const base::ListValue& val);
 };
 
 }  // namespace mate

--- a/common.gypi
+++ b/common.gypi
@@ -184,9 +184,7 @@
       ],
       'target_defaults': {
         'cflags_cc': [
-          # Use gnu++11 instead of c++11 here, see:
-          # https://code.google.com/p/chromium/issues/detail?id=224515
-          '-std=gnu++11',
+          '-std=c++11',
         ],
         'xcode_settings': {
           'CC': '/usr/bin/clang',
@@ -199,6 +197,8 @@
           ],
 
           'GCC_C_LANGUAGE_STANDARD': 'c99',  # -std=c99
+          'CLANG_CXX_LIBRARY': 'libc++',  # -stdlib=libc++
+          'CLANG_CXX_LANGUAGE_STANDARD': 'c++11',  # -std=c++11
         },
       },
     }],  # clang==1

--- a/common.gypi
+++ b/common.gypi
@@ -130,6 +130,14 @@
           }],  # OS=="linux"
         ],
       }],
+      ['_type in ["executable", "shared_library"]', {
+        # On some machines setting CLANG_CXX_LIBRARY doesn't work for linker.
+        'xcode_settings': {
+          'OTHER_LDFLAGS': [
+            '-stdlib=libc++'
+          ],
+        },
+      }],
     ],
     'msvs_cygwin_shell': 0, # Strangely setting it to 1 would make building under cygwin fail.
     'msvs_disabled_warnings': [
@@ -189,9 +197,6 @@
         'xcode_settings': {
           'CC': '/usr/bin/clang',
           'LDPLUSPLUS': '/usr/bin/clang++',
-          'OTHER_CPLUSPLUSFLAGS': [
-            '$(inherited)', '-std=gnu++11'
-          ],
           'OTHER_CFLAGS': [
             '-fcolor-diagnostics',
           ],

--- a/script/lib/config.py
+++ b/script/lib/config.py
@@ -4,7 +4,7 @@ import platform
 import sys
 
 BASE_URL = 'http://gh-contractor-zcbenz.s3.amazonaws.com/libchromiumcontent'
-LIBCHROMIUMCONTENT_COMMIT = '17a0e24666d0198810752284690bc2d0d87094d7'
+LIBCHROMIUMCONTENT_COMMIT = '6300862b4b16bd171f00ae566b697098c29743f7'
 
 ARCH = {
     'cygwin': '32bit',


### PR DESCRIPTION
This makes use of C++11 variadic templates to get rid of the conversion between `base::ListValue` when sending arguments from C++ to JavaScript.

It also makes the C++ code as simple as JavaScript:

```cpp
base::ListValue args;
args.AppendInteger(level);
args.AppendString(message);
args.AppendInteger(line_no);
args.AppendString(source_id);
Emit("console-message", args);
```

now becomes

```cpp
Emit("console-message", level, message, line_no, source_id);
```