### PR TITLE
Initialize ICU in Node mode

### DIFF
--- a/atom.gyp
+++ b/atom.gyp
@@ -340,8 +340,8 @@
       'chromium_src/chrome/browser/ui/views/color_chooser_win.cc',
     ],
     'framework_sources': [
-      'atom/app/atom_library_main.cc',
       'atom/app/atom_library_main.h',
+      'atom/app/atom_library_main.mm',
     ],
     'locales': [
       'am', 'ar', 'bg', 'bn', 'ca', 'cs', 'da', 'de', 'el', 'en-GB',
@@ -800,6 +800,9 @@
             '.',
             'vendor',
             '<(libchromiumcontent_include_dir)',
+          ],
+          'defines': [
+            'PRODUCT_NAME="<(product_name)"',
           ],
           'export_dependent_settings': [
             '<(project_name)_lib',

--- a/atom/app/atom_library_main.h
+++ b/atom/app/atom_library_main.h
@@ -11,6 +11,9 @@
 extern "C" {
 __attribute__((visibility("default")))
 int AtomMain(int argc, const char* argv[]);
+
+__attribute__((visibility("default")))
+void AtomInitializeICU();
 }
 #endif  // OS_MACOSX
 

--- a/atom/app/atom_library_main.mm
+++ b/atom/app/atom_library_main.mm
@@ -5,6 +5,9 @@
 #include "atom/app/atom_library_main.h"
 
 #include "atom/app/atom_main_delegate.h"
+#include "base/i18n/icu_util.h"
+#include "base/mac/bundle_locations.h"
+#include "brightray/common/mac/main_application_bundle.h"
 #include "content/public/app/content_main.h"
 
 #if defined(OS_MACOSX)
@@ -14,5 +17,14 @@ int AtomMain(int argc, const char* argv[]) {
   params.argc = argc;
   params.argv = argv;
   return content::ContentMain(params);
+}
+
+void AtomInitializeICU() {
+  base::mac::SetOverrideFrameworkBundlePath(
+      brightray::MainApplicationBundlePath()
+          .Append("Contents")
+          .Append("Frameworks")
+          .Append(PRODUCT_NAME " Framework.framework"));
+  base::i18n::InitializeICU();
 }
 #endif  // OS_MACOSX

--- a/atom/app/atom_main.cc
+++ b/atom/app/atom_main.cc
@@ -127,8 +127,10 @@ int main(int argc, const char* argv[]) {
 
 int main(int argc, const char* argv[]) {
   char* node_indicator = getenv("ATOM_SHELL_INTERNAL_RUN_AS_NODE");
-  if (node_indicator != NULL && strcmp(node_indicator, "1") == 0)
+  if (node_indicator != NULL && strcmp(node_indicator, "1") == 0) {
+    AtomInitializeICU();
     return node::Start(argc, const_cast<char**>(argv));
+  }
 
   return AtomMain(argc, argv);
 }

--- a/atom/app/atom_main.cc
+++ b/atom/app/atom_main.cc
@@ -28,6 +28,8 @@
 #include "atom/app/atom_library_main.h"
 #endif  // defined(OS_MACOSX)
 
+#include "base/i18n/icu_util.h"
+
 // Declaration of node::Start.
 namespace node {
 int Start(int argc, char *argv[]);
@@ -89,6 +91,7 @@ int APIENTRY wWinMain(HINSTANCE instance, HINSTANCE, wchar_t* cmd, int) {
       }
     }
     // Now that conversion is done, we can finally start.
+    base::i18n::InitializeICU();
     return node::Start(argc, argv);
   } else if (env->GetVar("ATOM_SHELL_INTERNAL_CRASH_SERVICE",
                          &crash_service_indicator) &&
@@ -113,8 +116,10 @@ int APIENTRY wWinMain(HINSTANCE instance, HINSTANCE, wchar_t* cmd, int) {
 
 int main(int argc, const char* argv[]) {
   char* node_indicator = getenv("ATOM_SHELL_INTERNAL_RUN_AS_NODE");
-  if (node_indicator != NULL && strcmp(node_indicator, "1") == 0)
+  if (node_indicator != NULL && strcmp(node_indicator, "1") == 0) {
+    base::i18n::InitializeICU();
     return node::Start(argc, const_cast<char**>(argv));
+  }
 
   atom::AtomMainDelegate delegate;
   content::ContentMainParams params(&delegate);

--- a/spec/fixtures/module/locale-compare.js
+++ b/spec/fixtures/module/locale-compare.js
@@ -1,0 +1,7 @@
+process.on('message', function (msg) {
+  process.send([
+    'a'.localeCompare('a'),
+    'ä'.localeCompare('z', 'de'),
+    'ä'.localeCompare('a', 'sv', { sensitivity: 'base' }),
+  ]);
+});

--- a/spec/node-spec.coffee
+++ b/spec/node-spec.coffee
@@ -41,6 +41,13 @@ describe 'node feature', ->
           done()
         child.send 'message'
 
+      it 'has String::localeCompare working in script', (done) ->
+        child = child_process.fork path.join(fixtures, 'module', 'locale-compare.js')
+        child.on 'message', (msg) ->
+          assert.deepEqual msg, [0, -1, 1]
+          done()
+        child.send 'message'
+
   describe 'contexts', ->
     describe 'setTimeout in fs callback', ->
       it 'does not crash', (done) ->


### PR DESCRIPTION
In atom-shell we are using V8 that compiled with ICU support, so we should initialize ICU when running as Node, otherwise things like `String::localeCompare` will crash in scripts ran by `child_process.fork`.

Fix #979.
Fix #961.