### PR TITLE
Friendly error message when missing a module

### DIFF
--- a/atom/browser/default_app/main.js
+++ b/atom/browser/default_app/main.js
@@ -48,7 +48,10 @@ if (option.file && !option.webdriver) {
   } catch(e) {
     if (e.code == 'MODULE_NOT_FOUND') {
       app.focus();
-      dialog.showErrorBox('Error opening app', 'The app provided is not a valid atom-shell app, please read the docs on how to write one:\nhttps://github.com/atom/atom-shell/tree/master/docs');
+      dialog.showErrorBox('Error opening app', 'Can\'t require() a module: ' + e.message + '\n'
+          'Some modules are only available in the browser process, others only in the client process. ' +
+          'See the docs for details:\n'+
+          'https://github.com/atom/atom-shell/tree/master/docs');
       process.exit(1);
     } else {
       console.error('App throwed an error when running', e);


### PR DESCRIPTION
I've gotten the following error message, when the actual problem was something else. Turns out it happens when any module fails to load. 

    Error opening app
    The app provided is not a valid atom-shell app, please read the docs on how to write one:
    https://github.com/atom/atom-shell/tree/master/docs

For example, if you take a hello-world atom-shell app and add `require('sqlite3')`, you'll get that cryptic error. The real reason is that atom-shell supports only a subset of the modules in standard node out of the box: native modules like sqlite3 don't always install easily because atom uses a newer version of V8 than standard node.

Small diff, just trying to clarify things!
