### PR TITLE
Add API to set/get path to special directory or file

### DIFF
--- a/atom/browser/api/atom_api_app.cc
+++ b/atom/browser/api/atom_api_app.cc
@@ -151,18 +151,26 @@ void App::OnFinishLaunching() {
   Emit("ready");
 }
 
-base::FilePath App::GetPath(const std::string& name) {
+base::FilePath App::GetPath(mate::Arguments* args, const std::string& name) {
+  bool succeed = false;
   base::FilePath path;
   int key = GetPathConstant(name);
   if (key >= 0)
-    PathService::Get(key, &path);
+    succeed = PathService::Get(key, &path);
+  if (!succeed)
+    args->ThrowError("Failed to get path");
   return path;
 }
 
-void App::SetPath(const std::string& name, const base::FilePath& path) {
+void App::SetPath(mate::Arguments* args,
+                  const std::string& name,
+                  const base::FilePath& path) {
+  bool succeed = false;
   int key = GetPathConstant(name);
   if (key >= 0)
-    PathService::Override(key, path);
+    succeed = PathService::Override(key, path);
+  if (!succeed)
+    args->ThrowError("Failed to set path");
 }
 
 void App::ResolveProxy(const GURL& url, ResolveProxyCallback callback) {

--- a/atom/browser/api/atom_api_app.cc
+++ b/atom/browser/api/atom_api_app.cc
@@ -73,6 +73,14 @@ int GetPathConstant(const std::string& name) {
     return brightray::DIR_USER_CACHE;
   else if (name == "home")
     return base::DIR_HOME;
+  else if (name == "temp")
+    return base::DIR_TEMP;
+  else if (name == "userDesktop")
+    return base::DIR_USER_DESKTOP;
+  else if (name == "exe")
+    return base::FILE_EXE;
+  else if (name == "module")
+    return base::FILE_MODULE;
   else
     return -1;
 }

--- a/atom/browser/api/atom_api_app.cc
+++ b/atom/browser/api/atom_api_app.cc
@@ -67,6 +67,8 @@ int GetPathConstant(const std::string& name) {
     return brightray::DIR_APP_DATA;
   else if (name == "userData")
     return brightray::DIR_USER_DATA;
+  else if (name == "home")
+    return base::DIR_HOME;
   else
     return -1;
 }

--- a/atom/browser/api/atom_api_app.cc
+++ b/atom/browser/api/atom_api_app.cc
@@ -67,6 +67,10 @@ int GetPathConstant(const std::string& name) {
     return brightray::DIR_APP_DATA;
   else if (name == "userData")
     return brightray::DIR_USER_DATA;
+  else if (name == "cache")
+    return brightray::DIR_CACHE;
+  else if (name == "userCache")
+    return brightray::DIR_USER_CACHE;
   else if (name == "home")
     return base::DIR_HOME;
   else

--- a/atom/browser/api/atom_api_app.h
+++ b/atom/browser/api/atom_api_app.h
@@ -18,6 +18,10 @@ namespace base {
 class FilePath;
 }
 
+namespace mate {
+class Arguments;
+}
+
 namespace atom {
 
 namespace api {
@@ -49,11 +53,11 @@ class App : public mate::EventEmitter,
 
  private:
   // Get/Set the pre-defined path in PathService.
-  base::FilePath GetPath(const std::string& name);
-  void SetPath(const std::string& name, const base::FilePath& path);
+  base::FilePath GetPath(mate::Arguments* args, const std::string& name);
+  void SetPath(mate::Arguments* args,
+               const std::string& name,
+               const base::FilePath& path);
 
-  void SetDataPath(const base::FilePath& path);
-  base::FilePath GetDataPath();
   void ResolveProxy(const GURL& url, ResolveProxyCallback callback);
   void SetDesktopName(const std::string& desktop_name);
 

--- a/atom/browser/api/atom_api_app.h
+++ b/atom/browser/api/atom_api_app.h
@@ -48,6 +48,10 @@ class App : public mate::EventEmitter,
       v8::Isolate* isolate) override;
 
  private:
+  // Get/Set the pre-defined path in PathService.
+  base::FilePath GetPath(const std::string& name);
+  void SetPath(const std::string& name, const base::FilePath& path);
+
   void SetDataPath(const base::FilePath& path);
   base::FilePath GetDataPath();
   void ResolveProxy(const GURL& url, ResolveProxyCallback callback);

--- a/atom/browser/api/atom_api_app.h
+++ b/atom/browser/api/atom_api_app.h
@@ -48,6 +48,7 @@ class App : public mate::EventEmitter,
       v8::Isolate* isolate) override;
 
  private:
+  void SetDataPath(const base::FilePath& path);
   base::FilePath GetDataPath();
   void ResolveProxy(const GURL& url, ResolveProxyCallback callback);
   void SetDesktopName(const std::string& desktop_name);

--- a/atom/browser/api/lib/app.coffee
+++ b/atom/browser/api/lib/app.coffee
@@ -5,15 +5,6 @@ bindings = process.atomBinding 'app'
 app = bindings.app
 app.__proto__ = EventEmitter.prototype
 
-app.getHomeDir = ->
-  process.env[if process.platform is 'win32' then 'USERPROFILE' else 'HOME']
-
-app.getDataPath = ->
-  app.getPath 'userData'
-
-app.setDataPath = (path) ->
-  app.setPath 'userData', path
-
 app.setApplicationMenu = (menu) ->
   require('menu').setApplicationMenu menu
 
@@ -38,6 +29,9 @@ if process.platform is 'darwin'
 app.once 'ready', -> app.emit 'finish-launching'
 app.terminate = app.quit
 app.exit = process.exit
+app.getHomeDir = -> app.getPath 'home'
+app.getDataPath = -> app.getPath 'userData'
+app.setDataPath = (path) -> app.setPath 'userData', path
 
 # Only one App object pemitted.
 module.exports = app

--- a/atom/browser/api/lib/app.coffee
+++ b/atom/browser/api/lib/app.coffee
@@ -8,6 +8,12 @@ app.__proto__ = EventEmitter.prototype
 app.getHomeDir = ->
   process.env[if process.platform is 'win32' then 'USERPROFILE' else 'HOME']
 
+app.getDataPath = ->
+  app.getPath 'userData'
+
+app.setDataPath = (path) ->
+  app.setPath 'userData', path
+
 app.setApplicationMenu = (menu) ->
   require('menu').setApplicationMenu menu
 

--- a/atom/browser/default_app/main.js
+++ b/atom/browser/default_app/main.js
@@ -41,6 +41,7 @@ if (option.file && !option.webdriver) {
         app.setName(packageJson.productName);
       else if (packageJson.name)
         app.setName(packageJson.name);
+      app.setPath('userData', path.join(app.getPath('appData'), app.getName()));
     }
 
     // Run the app.

--- a/atom/browser/default_app/main.js
+++ b/atom/browser/default_app/main.js
@@ -42,6 +42,7 @@ if (option.file && !option.webdriver) {
       else if (packageJson.name)
         app.setName(packageJson.name);
       app.setPath('userData', path.join(app.getPath('appData'), app.getName()));
+      app.setPath('userCache', path.join(app.getPath('cache'), app.getName()));
     }
 
     // Run the app.

--- a/atom/browser/lib/chrome-extension.coffee
+++ b/atom/browser/lib/chrome-extension.coffee
@@ -34,15 +34,9 @@ getExtensionInfoFromPath = (srcDirectory) ->
       srcDirectory: srcDirectory
     extensionInfoMap[manifest.name]
 
-# Load persistented extensions.
-loadedExtensionsPath = path.join app.getDataPath(), 'DevTools Extensions'
-
-try
-  loadedExtensions = JSON.parse fs.readFileSync(loadedExtensionsPath)
-  loadedExtensions = [] unless Array.isArray loadedExtensions
-  # Preheat the extensionInfo cache.
-  getExtensionInfoFromPath srcDirectory for srcDirectory in loadedExtensions
-catch e
+# The loaded extensions cache and its persistent path.
+loadedExtensions = null
+loadedExtensionsPath = null
 
 # Persistent loaded extensions.
 app.on 'will-quit', ->
@@ -58,6 +52,16 @@ app.on 'will-quit', ->
 app.once 'ready', ->
   protocol = require 'protocol'
   BrowserWindow = require 'browser-window'
+
+  # Load persistented extensions.
+  loadedExtensionsPath = path.join app.getDataPath(), 'DevTools Extensions'
+
+  try
+    loadedExtensions = JSON.parse fs.readFileSync(loadedExtensionsPath)
+    loadedExtensions = [] unless Array.isArray loadedExtensions
+    # Preheat the extensionInfo cache.
+    getExtensionInfoFromPath srcDirectory for srcDirectory in loadedExtensions
+  catch e
 
   # The chrome-extension: can map a extension URL request to real file path.
   protocol.registerProtocol 'chrome-extension', (request) ->

--- a/atom/browser/lib/init.coffee
+++ b/atom/browser/lib/init.coffee
@@ -90,8 +90,9 @@ process.once 'BIND_DONE', ->
   else
     app.setDesktopName '#{app.getName()}.desktop'
 
-  # Set the user data path according to application's name.
+  # Set the user path according to application's name.
   app.setPath 'userData', path.join(app.getPath('appData'), app.getName())
+  app.setPath 'userCache', path.join(app.getPath('cache'), app.getName())
 
   # Load the chrome extension support.
   require './chrome-extension.js'

--- a/atom/browser/lib/init.coffee
+++ b/atom/browser/lib/init.coffee
@@ -90,6 +90,9 @@ process.once 'BIND_DONE', ->
   else
     app.setDesktopName '#{app.getName()}.desktop'
 
+  # Set the user data path according to application's name.
+  app.setPath 'userData', path.join(app.getPath('appData'), app.getName())
+
   # Load the chrome extension support.
   require './chrome-extension.js'
 

--- a/docs/api/app.md
+++ b/docs/api/app.md
@@ -107,6 +107,12 @@ You can request following paths by the names:
   * `~/Library/Application Support` on OS X
 * `userData`: The directory for storing your app's configuration files, by
   default it is the `appData` directory appended with your app's name.
+* `cache`: Per-user application cache directory, by default it is pointed to:
+  * `%APPDATA%` on Window, which doesn't has a universal place for cache
+  * `$XDG_CACHE_HOME` on Linux
+  * `~/Library/Caches` on OS X
+* `userCache`: The directory for placing your app's caches, by default it is the
+ `cache` directory appended with your app's name.
 
 ## app.setPath(name, path)
 

--- a/docs/api/app.md
+++ b/docs/api/app.md
@@ -91,13 +91,33 @@ executed. It is possible that a window cancels the quitting by returning
 Quit the application directly, it will not try to close all windows so cleanup
 code will not run.
 
-## app.getDataPath()
+## app.getPath(name)
 
-Returns the path for storing configuration files, with app name appended.
+* `name` String
 
- * `%APPDATA%\MyAppName` on Windows
- * `~/.config/MyAppName` on Linux
- * `~/Library/Application Support/MyAppName` on OS X
+Retrieves a path to a special directory or file associated with `name`. On
+failure an `Error` would throw.
+
+You can request following paths by the names:
+
+* `home`: User's home directory
+* `appData`: Per-user application data directory, by default it is pointed to:
+  * `%APPDATA%` on Windows
+  * `~/.config` on Linux
+  * `~/Library/Application Support` on OS X
+* `userData`: The directory for storing your app's configuration files, by
+  default it is the `appData` directory appended with your app's name.
+
+## app.setPath(name, path)
+
+* `name` String
+* `path` String
+
+Overrides the `path` to a special directory or file associated with `name`. if
+the path specifies a directory that does not exist, the directory will be
+created by this method. On failure an `Error` would throw.
+
+You can only override paths of `name`s  defined in `app.getPath`.
 
 ## app.getVersion()
 

--- a/docs/api/app.md
+++ b/docs/api/app.md
@@ -106,13 +106,17 @@ You can request following paths by the names:
   * `$XDG_CONFIG_HOME` or `~/.config` on Linux
   * `~/Library/Application Support` on OS X
 * `userData`: The directory for storing your app's configuration files, by
-  default it is the `appData` directory appended with your app's name.
+  default it is the `appData` directory appended with your app's name
 * `cache`: Per-user application cache directory, by default it is pointed to:
   * `%APPDATA%` on Window, which doesn't has a universal place for cache
   * `$XDG_CACHE_HOME` or `~/.cache` on Linux
   * `~/Library/Caches` on OS X
 * `userCache`: The directory for placing your app's caches, by default it is the
- `cache` directory appended with your app's name.
+ `cache` directory appended with your app's name
+* `temp`: Temporary directory
+* `userDesktop`: The current user's Desktop directory
+* `exe`: The current executable file
+* `module`: The `libchromiumcontent` library
 
 ## app.setPath(name, path)
 

--- a/docs/api/app.md
+++ b/docs/api/app.md
@@ -119,6 +119,10 @@ created by this method. On failure an `Error` would throw.
 
 You can only override paths of `name`s  defined in `app.getPath`.
 
+By default web pages' cookies and caches will be stored under `userData`
+directory, if you want to change this location, you have to override the
+`userData` path before the `ready` event of `app` module gets emitted.
+
 ## app.getVersion()
 
 Returns the version of loaded application, if no version is found in

--- a/docs/api/app.md
+++ b/docs/api/app.md
@@ -103,13 +103,13 @@ You can request following paths by the names:
 * `home`: User's home directory
 * `appData`: Per-user application data directory, by default it is pointed to:
   * `%APPDATA%` on Windows
-  * `~/.config` on Linux
+  * `$XDG_CONFIG_HOME` or `~/.config` on Linux
   * `~/Library/Application Support` on OS X
 * `userData`: The directory for storing your app's configuration files, by
   default it is the `appData` directory appended with your app's name.
 * `cache`: Per-user application cache directory, by default it is pointed to:
   * `%APPDATA%` on Window, which doesn't has a universal place for cache
-  * `$XDG_CACHE_HOME` on Linux
+  * `$XDG_CACHE_HOME` or `~/.cache` on Linux
   * `~/Library/Caches` on OS X
 * `userCache`: The directory for placing your app's caches, by default it is the
  `cache` directory appended with your app's name.


### PR DESCRIPTION
```markdown
## app.getPath(name)

* `name` String

Retrieves a path to a special directory or file associated with `name`. On
failure an `Error` would throw.

You can request following paths by the names:

* `home`: User's home directory
* `appData`: Per-user application data directory, by default it is pointed to:
  * `%APPDATA%` on Windows
  * `$XDG_CONFIG_HOME` or `~/.config` on Linux
  * `~/Library/Application Support` on OS X
* `userData`: The directory for storing your app's configuration files, by
  default it is the `appData` directory appended with your app's name
* `cache`: Per-user application cache directory, by default it is pointed to:
  * `%APPDATA%` on Window, which doesn't has a universal place for cache
  * `$XDG_CACHE_HOME` or `~/.cache` on Linux
  * `~/Library/Caches` on OS X
* `userCache`: The directory for placing your app's caches, by default it is the
 `cache` directory appended with your app's name
* `temp`: Temporary directory
* `userDesktop`: The current user's Desktop directory
* `exe`: The current executable file
* `module`: The `libchromiumcontent` library

## app.setPath(name, path)

* `name` String
* `path` String

Overrides the `path` to a special directory or file associated with `name`. if
the path specifies a directory that does not exist, the directory will be
created by this method. On failure an `Error` would throw.

You can only override paths of `name`s  defined in `app.getPath`.

By default web pages' cookies and caches will be stored under `userData`
directory, if you want to change this location, you have to override the
`userData` path before the `ready` event of `app` module gets emitted.
```

`app.getDataPath()` will be deprecated by `app.getPath('userData')`, and users can use `app.setPath('userData', ...)` to override the user data path. Fixes #647.