### PR TITLE
Update index.json when publishing

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   ],
 
   "devDependencies": {
-    "atom-package-manager": "0.112.0",
+    "atom-package-manager": "0.122.0",
     "coffee-script": "~1.7.1",
     "coffeelint": "~1.3.0",
     "request": "*"

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
   "devDependencies": {
     "atom-package-manager": "0.112.0",
     "coffee-script": "~1.7.1",
-    "coffeelint": "~1.3.0"
+    "coffeelint": "~1.3.0",
+    "request": "*"
   },
 
   "private": true,

--- a/script/dump-version-info.js
+++ b/script/dump-version-info.js
@@ -28,7 +28,7 @@ function getInfoForCurrentVersion() {
   json.date = getDate();
   json.apm = getApmVersion();
 
-  var names = ['v8', 'uv', 'zlib', 'openssl', 'modules', 'chrome']
+  var names = ['node', 'v8', 'uv', 'zlib', 'openssl', 'modules', 'chrome']
   for (var i in names) {
     var name = names[i];
     json[name] = process.versions[name];

--- a/script/dump-version-info.js
+++ b/script/dump-version-info.js
@@ -1,5 +1,6 @@
 var app = require('app');
 var fs = require('fs');
+var path = require('path');
 var request = require('request');
 
 var TARGET_URL = 'http://gh-contractor-zcbenz.s3.amazonaws.com/atom-shell/dist/index.json';
@@ -16,10 +17,16 @@ function getDate() {
   return year + '-' + month + '-' + day;
 }
 
+function getApmVersion() {
+  var package = require(path.resolve(__dirname, '..', 'package.json'));
+  return package.devDependencies['atom-package-manager'];
+}
+
 function getInfoForCurrentVersion() {
   var json = {};
   json.version = process.versions['atom-shell'];
   json.date = getDate();
+  json.apm = getApmVersion();
 
   var names = ['v8', 'uv', 'zlib', 'openssl', 'modules', 'chrome']
   for (var i in names) {

--- a/script/dump_info.js
+++ b/script/dump_info.js
@@ -1,0 +1,39 @@
+var app = require('app');
+
+function getDate() {
+  var today = new Date();
+  var year = today.getFullYear();
+  var month = today.getMonth() + 1;
+  if (month <= 9)
+    month = '0' + month;
+  var day= today.getDate();
+  if (day <= 9)
+    day = '0' + day;
+  return year + '-' + month + '-' + day;
+}
+
+app.on('ready', function() {
+  var json = {};
+  json.version = process.versions['atom-shell'];
+  json.date = getDate();
+
+  var names = ['v8', 'uv', 'zlib', 'openssl', 'modules', 'chrome']
+  for (var i in names) {
+    var name = names[i];
+    json[name] = process.versions[name];
+  }
+
+  json.files = [
+    'darwin-x64',
+    'darwin-x64-symbols',
+    'linux-ia32',
+    'linux-ia32-symbols',
+    'linux-x64',
+    'linux-x64-symbols',
+    'win32-ia32',
+    'win32-ia32-symbols',
+  ];
+
+  console.log(json);
+  process.exit(0);
+});

--- a/script/upload.py
+++ b/script/upload.py
@@ -196,7 +196,8 @@ def upload_node(bucket, access_key, secret_key, version):
     execute([atom_shell,
              os.path.join(SOURCE_ROOT, 'script', 'dump-version-info.js'),
              index_json])
-    s3put(bucket, access_key, secret_key, OUT_DIR, 'atom-shell', [index_json])
+    s3put(bucket, access_key, secret_key, OUT_DIR, 'atom-shell/dist',
+          [index_json])
 
 
 def auth_token():

--- a/script/upload.py
+++ b/script/upload.py
@@ -190,6 +190,14 @@ def upload_node(bucket, access_key, secret_key, version):
     s3put(bucket, access_key, secret_key, OUT_DIR,
           'atom-shell/dist/{0}'.format(version), [node_lib])
 
+    # Upload the index.json
+    atom_shell = os.path.join(OUT_DIR, 'atom.exe')
+    index_json = os.path.join(OUT_DIR, 'index.json')
+    execute([atom_shell,
+             os.path.join(SOURCE_ROOT, 'script', 'dump-version-info.js'),
+             index_json])
+    s3put(bucket, access_key, secret_key, OUT_DIR, 'atom-shell', [index_json])
+
 
 def auth_token():
   token = os.environ.get('ATOM_SHELL_GITHUB_TOKEN')


### PR DESCRIPTION
We now maintain a `index.json` file that records the the V8 version and apm version for each release of atom-shell, the URL is:

```
http://gh-contractor-zcbenz.s3.amazonaws.com/atom-shell/dist/index.json
```

This is to match io.js(https://iojs.org/download/release/index.json) to make it easy to get ABI compatibility information of each release, fixes #1022.