### PR TITLE
Add screen to common api

### DIFF
--- a/atom.gyp
+++ b/atom.gyp
@@ -39,6 +39,7 @@
       'atom/common/api/lib/crash-reporter.coffee',
       'atom/common/api/lib/id-weak-map.coffee',
       'atom/common/api/lib/original-fs.coffee',
+      'atom/common/api/lib/screen.coffee',
       'atom/common/api/lib/shell.coffee',
       'atom/common/lib/init.coffee',
       'atom/common/lib/asar.coffee',

--- a/atom/common/api/lib/screen.coffee
+++ b/atom/common/api/lib/screen.coffee
@@ -1,0 +1,1 @@
+module.exports = require('remote').require('screen')


### PR DESCRIPTION
@zcbenz,  I attempted to update atom to `v0.20.7` of `atom-shell`, and it threw an error trying to get `screen.js` from the common api.  Not sure if this is the correct way to fix this, but it seems to work.