### PR TITLE
Make asar support work with graceful-fs

### DIFF
--- a/atom/common/api/lib/original-fs.coffee
+++ b/atom/common/api/lib/original-fs.coffee
@@ -2,7 +2,7 @@ vm = require 'vm'
 
 # Execute the 'fs.js' and pass the 'exports' to it.
 source = '(function (exports, require, module, __filename, __dirname) { ' +
-         process.binding('natives').fs +
+         process.binding('natives').originalFs +
          '\n});'
 fn = vm.runInThisContext source, { filename: 'fs.js' }
 fn exports, require, module

--- a/atom/common/lib/init.coffee
+++ b/atom/common/lib/init.coffee
@@ -50,6 +50,6 @@ source.fs = """
   var vm = require('vm');
   var fn = vm.runInThisContext(src, { filename: 'fs.js' });
   fn(exports, require, module);
-  var asar = require('#{__dirname}/asar');
+  var asar = require(#{JSON.stringify(__dirname)} + '/asar');
   asar.wrapFsWithAsar(exports);
 """

--- a/atom/common/lib/init.coffee
+++ b/atom/common/lib/init.coffee
@@ -1,4 +1,5 @@
 process = global.process
+fs      = require 'fs'
 path    = require 'path'
 timers  = require 'timers'
 Module  = require 'module'
@@ -36,4 +37,5 @@ if process.type is 'browser'
   global.setInterval = wrapWithActivateUvLoop timers.setInterval
 
 # Add support for asar packages.
-require './asar'
+asar = require './asar'
+asar.wrapFsWithAsar fs

--- a/atom/common/lib/init.coffee
+++ b/atom/common/lib/init.coffee
@@ -39,3 +39,8 @@ if process.type is 'browser'
 # Add support for asar packages.
 asar = require './asar'
 asar.wrapFsWithAsar fs
+
+# Make graceful-fs work with asar.
+source = process.binding 'natives'
+source.originalFs = source.fs
+source.fs = "module.exports = require('fs');"

--- a/atom/common/lib/init.coffee
+++ b/atom/common/lib/init.coffee
@@ -43,4 +43,13 @@ asar.wrapFsWithAsar fs
 # Make graceful-fs work with asar.
 source = process.binding 'natives'
 source.originalFs = source.fs
-source.fs = "module.exports = require('fs');"
+source.fs = """
+  var src = '(function (exports, require, module, __filename, __dirname) { ' +
+            process.binding('natives').originalFs +
+            ' });';
+  var vm = require('vm');
+  var fn = vm.runInThisContext(src, { filename: 'fs.js' });
+  fn(exports, require, module);
+  var asar = require('#{__dirname}/asar');
+  asar.wrapFsWithAsar(exports);
+"""

--- a/spec/asar-spec.coffee
+++ b/spec/asar-spec.coffee
@@ -412,3 +412,9 @@ describe 'asar package', ->
       file = path.join fixtures, 'asar', 'a.asar'
       stats = originalFs.statSync file
       assert stats.isFile()
+
+  describe 'graceful-fs module', ->
+    it 'recognize asar archvies', ->
+      gfs = require 'graceful-fs'
+      p = path.join fixtures, 'asar', 'a.asar', 'link1'
+      assert.equal gfs.readFileSync(p).toString(), 'file1\n'

--- a/spec/asar-spec.coffee
+++ b/spec/asar-spec.coffee
@@ -414,7 +414,11 @@ describe 'asar package', ->
       assert stats.isFile()
 
   describe 'graceful-fs module', ->
+    gfs = require 'graceful-fs'
+
     it 'recognize asar archvies', ->
-      gfs = require 'graceful-fs'
       p = path.join fixtures, 'asar', 'a.asar', 'link1'
       assert.equal gfs.readFileSync(p).toString(), 'file1\n'
+
+    it 'does not touch global fs object', ->
+      assert.notEqual fs.readdir, gfs.readdir

--- a/spec/package.json
+++ b/spec/package.json
@@ -6,6 +6,7 @@
 
   "devDependencies": {
     "formidable": "1.0.16",
+    "graceful-fs": "3.0.5",
     "q": "0.9.7",
     "mocha": "2.1.0",
     "runas": "2.x",


### PR DESCRIPTION
The graceful-fs has its own way of wrapping around `fs` module, which bypasses our monkey-patching on it, This PR fixes it by providing fake `fs.js` source code to graceful-fs.

Fixes #1078.