### PR TITLE
[WIP] Fix #1074: build atom-shell on Linux

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -83,6 +83,8 @@
         'conditions': [
           ['OS=="linux"', {
             'cflags': [
+              '-D_GNU_SOURCE',
+              '-D__STRICT_ANSI__',
               '-Wno-parentheses-equality',
               '-Wno-unused-function',
               '-Wno-sometimes-uninitialized',
@@ -126,6 +128,7 @@
           ['OS=="linux"', {
             'cflags': [
               '-Wno-empty-body',
+              '-D__STRICT_ANSI__'
             ],
           }],  # OS=="linux"
         ],


### PR DESCRIPTION
This doesn't quite work yet. The goal is to make atom-shell compile on Ubuntu.

See #1074 for details.