### PR TITLE
Set window overlay icon

### DIFF
--- a/atom/browser/api/atom_api_window.cc
+++ b/atom/browser/api/atom_api_window.cc
@@ -487,6 +487,7 @@ void Window::BuildPrototype(v8::Isolate* isolate,
       .SetMethod("capturePage", &Window::CapturePage)
       .SetMethod("print", &Window::Print)
       .SetMethod("setProgressBar", &Window::SetProgressBar)
+      .SetMethod("setOverlayIcon", &Window::SetOverlayIcon)
       .SetMethod("setAutoHideMenuBar", &Window::SetAutoHideMenuBar)
       .SetMethod("isMenuBarAutoHide", &Window::IsMenuBarAutoHide)
       .SetMethod("setMenuBarVisibility", &Window::SetMenuBarVisibility)

--- a/atom/browser/api/atom_api_window.cc
+++ b/atom/browser/api/atom_api_window.cc
@@ -405,6 +405,11 @@ void Window::SetProgressBar(double progress) {
   window_->SetProgressBar(progress);
 }
 
+void Window::SetOverlayIcon(const gfx::Image& overlay,
+  const std::string& description) {
+  window_->SetOverlayIcon(overlay, description);
+}
+
 void Window::SetAutoHideMenuBar(bool auto_hide) {
   window_->SetAutoHideMenuBar(auto_hide);
 }

--- a/atom/browser/api/atom_api_window.cc
+++ b/atom/browser/api/atom_api_window.cc
@@ -2,10 +2,6 @@
 // Use of this source code is governed by the MIT license that can be
 // found in the LICENSE file.
 
-namespace gfx {
-class Image;
-}
-
 #include "atom/browser/api/atom_api_window.h"
 
 #include "atom/browser/api/atom_api_web_contents.h"
@@ -13,8 +9,8 @@ class Image;
 #include "atom/browser/native_window.h"
 #include "atom/common/native_mate_converters/gfx_converter.h"
 #include "atom/common/native_mate_converters/gurl_converter.h"
-#include "atom/common/native_mate_converters/string16_converter.h"
 #include "atom/common/native_mate_converters/image_converter.h"
+#include "atom/common/native_mate_converters/string16_converter.h"
 #include "content/public/browser/render_process_host.h"
 #include "native_mate/callback.h"
 #include "native_mate/constructor.h"
@@ -406,7 +402,7 @@ void Window::SetProgressBar(double progress) {
 }
 
 void Window::SetOverlayIcon(const gfx::Image& overlay,
-  const std::string& description) {
+                            const std::string& description) {
   window_->SetOverlayIcon(overlay, description);
 }
 

--- a/atom/browser/api/atom_api_window.cc
+++ b/atom/browser/api/atom_api_window.cc
@@ -2,6 +2,10 @@
 // Use of this source code is governed by the MIT license that can be
 // found in the LICENSE file.
 
+namespace gfx {
+class Image;
+}
+
 #include "atom/browser/api/atom_api_window.h"
 
 #include "atom/browser/api/atom_api_web_contents.h"
@@ -10,6 +14,7 @@
 #include "atom/common/native_mate_converters/gfx_converter.h"
 #include "atom/common/native_mate_converters/gurl_converter.h"
 #include "atom/common/native_mate_converters/string16_converter.h"
+#include "atom/common/native_mate_converters/image_converter.h"
 #include "content/public/browser/render_process_host.h"
 #include "native_mate/callback.h"
 #include "native_mate/constructor.h"

--- a/atom/browser/api/atom_api_window.h
+++ b/atom/browser/api/atom_api_window.h
@@ -118,6 +118,7 @@ class Window : public mate::EventEmitter,
   void CapturePage(mate::Arguments* args);
   void Print(mate::Arguments* args);
   void SetProgressBar(double progress);
+  void SetOverlayIcon(gfx::ImageSkia& overlay, const std::string& description);
   void SetAutoHideMenuBar(bool auto_hide);
   bool IsMenuBarAutoHide();
   void SetMenuBarVisibility(bool visible);

--- a/atom/browser/api/atom_api_window.h
+++ b/atom/browser/api/atom_api_window.h
@@ -9,6 +9,7 @@
 #include <vector>
 
 #include "base/memory/scoped_ptr.h"
+#include "ui/gfx/image/image.h"
 #include "atom/browser/native_window_observer.h"
 #include "atom/browser/api/event_emitter.h"
 #include "native_mate/handle.h"
@@ -118,7 +119,7 @@ class Window : public mate::EventEmitter,
   void CapturePage(mate::Arguments* args);
   void Print(mate::Arguments* args);
   void SetProgressBar(double progress);
-  void SetOverlayIcon(const gfx::ImageSkia& overlay,
+  void SetOverlayIcon(const gfx::Image& overlay,
                       const std::string& description);
   void SetAutoHideMenuBar(bool auto_hide);
   bool IsMenuBarAutoHide();

--- a/atom/browser/api/atom_api_window.h
+++ b/atom/browser/api/atom_api_window.h
@@ -118,7 +118,8 @@ class Window : public mate::EventEmitter,
   void CapturePage(mate::Arguments* args);
   void Print(mate::Arguments* args);
   void SetProgressBar(double progress);
-  void SetOverlayIcon(gfx::ImageSkia& overlay, const std::string& description);
+  void SetOverlayIcon(const gfx::ImageSkia& overlay,
+                      const std::string& description);
   void SetAutoHideMenuBar(bool auto_hide);
   bool IsMenuBarAutoHide();
   void SetMenuBarVisibility(bool visible);

--- a/atom/browser/native_window.h
+++ b/atom/browser/native_window.h
@@ -142,6 +142,7 @@ class NativeWindow : public brightray::DefaultWebContentsDelegate,
   virtual bool HasModalDialog();
   virtual gfx::NativeWindow GetNativeWindow() = 0;
   virtual void SetProgressBar(double progress) = 0;
+  virtual void SetOverlayIcon(gfx::ImageSkia& overlay, const std::string& description) = 0;
 
   virtual bool IsClosed() const { return is_closed_; }
   virtual void OpenDevTools();

--- a/atom/browser/native_window.h
+++ b/atom/browser/native_window.h
@@ -21,7 +21,7 @@
 #include "content/public/browser/notification_registrar.h"
 #include "content/public/browser/notification_observer.h"
 #include "native_mate/persistent_dictionary.h"
-#include "ui/gfx/image/image_skia.h"
+#include "ui/gfx/image/image.h"
 
 namespace base {
 class CommandLine;
@@ -142,7 +142,7 @@ class NativeWindow : public brightray::DefaultWebContentsDelegate,
   virtual bool HasModalDialog();
   virtual gfx::NativeWindow GetNativeWindow() = 0;
   virtual void SetProgressBar(double progress) = 0;
-  virtual void SetOverlayIcon(const gfx::ImageSkia& overlay,
+  virtual void SetOverlayIcon(const gfx::Image& overlay,
                               const std::string& description) = 0;
 
   virtual bool IsClosed() const { return is_closed_; }

--- a/atom/browser/native_window.h
+++ b/atom/browser/native_window.h
@@ -142,7 +142,8 @@ class NativeWindow : public brightray::DefaultWebContentsDelegate,
   virtual bool HasModalDialog();
   virtual gfx::NativeWindow GetNativeWindow() = 0;
   virtual void SetProgressBar(double progress) = 0;
-  virtual void SetOverlayIcon(gfx::ImageSkia& overlay, const std::string& description) = 0;
+  virtual void SetOverlayIcon(const gfx::ImageSkia& overlay,
+                              const std::string& description) = 0;
 
   virtual bool IsClosed() const { return is_closed_; }
   virtual void OpenDevTools();

--- a/atom/browser/native_window_mac.h
+++ b/atom/browser/native_window_mac.h
@@ -71,6 +71,8 @@ class NativeWindowMac : public NativeWindow {
   bool HasModalDialog() override;
   gfx::NativeWindow GetNativeWindow() override;
   void SetProgressBar(double progress) override;
+  void SetOverlayIcon(const gfx::Image& overlay,
+    const std::string& description) override;
   void ShowDefinitionForSelection() override;
 
   // Returns true if |point| in local Cocoa coordinate system falls within

--- a/atom/browser/native_window_mac.h
+++ b/atom/browser/native_window_mac.h
@@ -72,7 +72,7 @@ class NativeWindowMac : public NativeWindow {
   gfx::NativeWindow GetNativeWindow() override;
   void SetProgressBar(double progress) override;
   void SetOverlayIcon(const gfx::Image& overlay,
-    const std::string& description) override;
+                      const std::string& description) override;
   void ShowDefinitionForSelection() override;
 
   // Returns true if |point| in local Cocoa coordinate system falls within

--- a/atom/browser/native_window_mac.mm
+++ b/atom/browser/native_window_mac.mm
@@ -678,6 +678,10 @@ void NativeWindowMac::SetProgressBar(double progress) {
   [dock_tile display];
 }
 
+void NativeWindowMac::SetOverlayIcon(const gfx::Image& overlay, 
+  const std::string& description) {
+}
+
 void NativeWindowMac::ShowDefinitionForSelection() {
   content::WebContents* web_contents = GetWebContents();
   if (!web_contents)

--- a/atom/browser/native_window_mac.mm
+++ b/atom/browser/native_window_mac.mm
@@ -678,8 +678,8 @@ void NativeWindowMac::SetProgressBar(double progress) {
   [dock_tile display];
 }
 
-void NativeWindowMac::SetOverlayIcon(const gfx::Image& overlay, 
-  const std::string& description) {
+void NativeWindowMac::SetOverlayIcon(const gfx::Image& overlay,
+                                     const std::string& description) {
 }
 
 void NativeWindowMac::ShowDefinitionForSelection() {

--- a/atom/browser/native_window_views.cc
+++ b/atom/browser/native_window_views.cc
@@ -613,7 +613,7 @@ void NativeWindowViews::SetProgressBar(double progress) {
 #endif
 }
 
-void NativeWindowViews::SetOverlayIcon(gfx::ImageSkia& overlay, std::string& description) {
+void NativeWindowViews::SetOverlayIcon(gfx::ImageSkia& overlay, const std::string& description) {
 #if defined(OS_WIN)
   if (base::win::GetVersion() < base::win::VERSION_WIN7)
     return;

--- a/atom/browser/native_window_views.cc
+++ b/atom/browser/native_window_views.cc
@@ -10,6 +10,7 @@
 
 #include <string>
 #include <vector>
+
 #include "atom/browser/ui/views/menu_bar.h"
 #include "atom/browser/ui/views/menu_layout.h"
 #include "atom/common/draggable_region.h"
@@ -51,8 +52,8 @@
 #include "base/win/scoped_comptr.h"
 #include "base/win/windows_version.h"
 #include "ui/base/win/shell.h"
-#include "ui/gfx/win/dpi.h"
 #include "ui/gfx/icon_util.h"
+#include "ui/gfx/win/dpi.h"
 #include "ui/views/win/hwnd_util.h"
 #endif
 
@@ -614,9 +615,8 @@ void NativeWindowViews::SetProgressBar(double progress) {
 #endif
 }
 
-void NativeWindowViews::SetOverlayIcon(
-  const gfx::Image& overlay,
-  const std::string& description) {
+void NativeWindowViews::SetOverlayIcon(const gfx::Image& overlay,
+                                       const std::string& description) {
 #if defined(OS_WIN)
   if (base::win::GetVersion() < base::win::VERSION_WIN7)
     return;
@@ -632,8 +632,8 @@ void NativeWindowViews::SetOverlayIcon(
 
   std::wstring wstr = std::wstring(description.begin(), description.end());
   taskbar->SetOverlayIcon(frame,
-    IconUtil::CreateHICONFromSkBitmap(overlay.AsBitmap()),
-    wstr.c_str());
+      IconUtil::CreateHICONFromSkBitmap(overlay.AsBitmap()),
+      wstr.c_str());
 #endif
 }
 

--- a/atom/browser/native_window_views.cc
+++ b/atom/browser/native_window_views.cc
@@ -10,7 +10,6 @@
 
 #include <string>
 #include <vector>
-
 #include "atom/browser/ui/views/menu_bar.h"
 #include "atom/browser/ui/views/menu_layout.h"
 #include "atom/common/draggable_region.h"
@@ -22,6 +21,8 @@
 #include "ui/aura/window.h"
 #include "ui/aura/window_tree_host.h"
 #include "ui/base/hit_test.h"
+#include "ui/gfx/icon_util.h"
+#include "ui/gfx/image/image.h"
 #include "ui/views/background.h"
 #include "ui/views/controls/webview/unhandled_keyboard_event_handler.h"
 #include "ui/views/controls/webview/webview.h"
@@ -614,7 +615,7 @@ void NativeWindowViews::SetProgressBar(double progress) {
 }
 
 void NativeWindowViews::SetOverlayIcon(
-  const gfx::ImageSkia& overlay,
+  const gfx::Image& overlay,
   const std::string& description) {
 #if defined(OS_WIN)
   if (base::win::GetVersion() < base::win::VERSION_WIN7)

--- a/atom/browser/native_window_views.cc
+++ b/atom/browser/native_window_views.cc
@@ -613,7 +613,9 @@ void NativeWindowViews::SetProgressBar(double progress) {
 #endif
 }
 
-void NativeWindowViews::SetOverlayIcon(gfx::ImageSkia& overlay, const std::string& description) {
+void NativeWindowViews::SetOverlayIcon(
+  const gfx::ImageSkia& overlay,
+  const std::string& description) {
 #if defined(OS_WIN)
   if (base::win::GetVersion() < base::win::VERSION_WIN7)
     return;
@@ -624,8 +626,12 @@ void NativeWindowViews::SetOverlayIcon(gfx::ImageSkia& overlay, const std::strin
       FAILED(taskbar->HrInit()))) {
     return;
   }
+
   HWND frame = views::HWNDForNativeWindow(GetNativeWindow());
-  taskbar->SetOverlayIcon(frame, IconUtil::CreateHICONFromSkiaBitmap(overlay.AsBitmap()), description);
+
+  taskbar->SetOverlayIcon(frame,
+    IconUtil::CreateHICONFromSkiaBitmap(overlay.AsBitmap()),
+    description);
 #endif
 }
 

--- a/atom/browser/native_window_views.cc
+++ b/atom/browser/native_window_views.cc
@@ -613,6 +613,22 @@ void NativeWindowViews::SetProgressBar(double progress) {
 #endif
 }
 
+void NativeWindowViews::SetOverlayIcon(gfx::ImageSkia& overlay, std::string& description) {
+#if defined(OS_WIN)
+  if (base::win::GetVersion() < base::win::VERSION_WIN7)
+    return;
+
+  base::win::ScopedComPtr<ITaskbarList3> taskbar;
+  if (FAILED(taskbar.CreateInstance(CLSID_TaskbarList, NULL,
+                                    CLSCTX_INPROC_SERVER) ||
+      FAILED(taskbar->HrInit()))) {
+    return;
+  }
+  HWND frame = views::HWNDForNativeWindow(GetNativeWindow());
+  taskbar->SetOverlayIcon(frame, IconUtil::CreateHICONFromSkiaBitmap(overlay.AsBitmap()), description);
+#endif
+}
+
 void NativeWindowViews::SetAutoHideMenuBar(bool auto_hide) {
   menu_bar_autohide_ = auto_hide;
 }

--- a/atom/browser/native_window_views.cc
+++ b/atom/browser/native_window_views.cc
@@ -21,7 +21,6 @@
 #include "ui/aura/window.h"
 #include "ui/aura/window_tree_host.h"
 #include "ui/base/hit_test.h"
-#include "ui/gfx/icon_util.h"
 #include "ui/gfx/image/image.h"
 #include "ui/views/background.h"
 #include "ui/views/controls/webview/unhandled_keyboard_event_handler.h"
@@ -53,6 +52,7 @@
 #include "base/win/windows_version.h"
 #include "ui/base/win/shell.h"
 #include "ui/gfx/win/dpi.h"
+#include "ui/gfx/icon_util.h"
 #include "ui/views/win/hwnd_util.h"
 #endif
 

--- a/atom/browser/native_window_views.cc
+++ b/atom/browser/native_window_views.cc
@@ -630,9 +630,10 @@ void NativeWindowViews::SetOverlayIcon(
 
   HWND frame = views::HWNDForNativeWindow(GetNativeWindow());
 
+  std::wstring wstr = std::wstring(description.begin(), description.end());
   taskbar->SetOverlayIcon(frame,
-    IconUtil::CreateHICONFromSkiaBitmap(overlay.AsBitmap()),
-    description);
+    IconUtil::CreateHICONFromSkBitmap(overlay.AsBitmap()),
+    wstr.c_str());
 #endif
 }
 

--- a/atom/browser/native_window_views.h
+++ b/atom/browser/native_window_views.h
@@ -73,7 +73,8 @@ class NativeWindowViews : public NativeWindow,
   bool IsKiosk() override;
   void SetMenu(ui::MenuModel* menu_model) override;
   gfx::NativeWindow GetNativeWindow() override;
-  void SetOverlayIcon(gfx::ImageSkia& overlay, std::string& description) override;
+  void SetOverlayIcon(const gfx::ImageSkia& overlay,
+                      const std::string& description) override;
   void SetProgressBar(double value) override;
   void SetAutoHideMenuBar(bool auto_hide) override;
   bool IsMenuBarAutoHide() override;

--- a/atom/browser/native_window_views.h
+++ b/atom/browser/native_window_views.h
@@ -73,6 +73,7 @@ class NativeWindowViews : public NativeWindow,
   bool IsKiosk() override;
   void SetMenu(ui::MenuModel* menu_model) override;
   gfx::NativeWindow GetNativeWindow() override;
+  void SetOverlayIcon(gfx::ImageSkia& overlay, std::string& description) override;
   void SetProgressBar(double value) override;
   void SetAutoHideMenuBar(bool auto_hide) override;
   bool IsMenuBarAutoHide() override;

--- a/atom/browser/native_window_views.h
+++ b/atom/browser/native_window_views.h
@@ -73,7 +73,7 @@ class NativeWindowViews : public NativeWindow,
   bool IsKiosk() override;
   void SetMenu(ui::MenuModel* menu_model) override;
   gfx::NativeWindow GetNativeWindow() override;
-  void SetOverlayIcon(const gfx::ImageSkia& overlay,
+  void SetOverlayIcon(const gfx::Image& overlay,
                       const std::string& description) override;
   void SetProgressBar(double value) override;
   void SetAutoHideMenuBar(bool auto_hide) override;

--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -543,7 +543,6 @@ it will assume `app.getName().desktop`.
 ### BrowserWindow.setOverlayIcon(overlay, description)
 
 * `overlay` [Image](image.md) - the icon to display on the bottom right corner of the Taskbar icon. If this parameter is `null`, the overlay is cleared.
-
 * `description` String - a description that will be provided to Accessibility screenreaders
 
 Sets a 16px overlay onto the current Taskbar icon, usually used to convey some sort of application status or to passively notify the user.

--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -540,6 +540,16 @@ On Linux platform, only supports Unity desktop environment, you need to specify
 the `*.desktop` file name to `desktopName` field in `package.json`. By default,
 it will assume `app.getName().desktop`.
 
+### BrowserWindow.setOverlayIcon(overlay, description)
+
+* `overlay` [Image](image.md) - the icon to display on the bottom right corner of the Taskbar icon. If this parameter is `null`, the overlay is cleared.
+
+* `description` String - a description that will be provided to Accessibility screenreaders
+
+Sets a 16px overlay onto the current Taskbar icon, usually used to convey some sort of application status or to passively notify the user.
+
+__Note:__ This API is only available on Windows, Win7 or above
+
 ### BrowserWindow.showDefinitionForSelection()
 
 Shows pop-up dictionary that searches the selected word on the page.


### PR DESCRIPTION
This PR adds a JS method for setting the Overlay Icon (the green jewel in the screenshot below):

![](https://i-msdn.sec.s-msft.com/dynimg/IC420441.png)

## TODO:

- [x] Actually get this working
- [x] Docs
- [x] Make sure it does nothing on OS X / Linux