### PR TITLE
Add "type" option to change window type of BrowserWindow

### DIFF
--- a/atom/browser/native_window_views.cc
+++ b/atom/browser/native_window_views.cc
@@ -225,6 +225,11 @@ NativeWindowViews::NativeWindowViews(content::WebContents* web_contents,
     ui::SetAtomArrayProperty(GetAcceleratedWidget(), "_NET_WM_STATE", "ATOM",
                              state_atom_list);
   }
+
+  // Set the _NET_WM_WINDOW_TYPE.
+  std::string window_type;
+  if (options.Get(switches::kType, &window_type))
+    SetWindowType(GetAcceleratedWidget(), window_type);
 #endif
 
   // Add web view.

--- a/atom/browser/ui/x/x_window_utils.cc
+++ b/atom/browser/ui/x/x_window_utils.cc
@@ -4,6 +4,9 @@
 
 #include "atom/browser/ui/x/x_window_utils.h"
 
+#include <X11/Xatom.h>
+
+#include "base/strings/string_util.h"
 #include "ui/base/x/x11_util.h"
 
 namespace atom {
@@ -29,6 +32,18 @@ void SetWMSpecState(::Window xwindow, bool enabled, ::Atom state) {
   XSendEvent(xdisplay, DefaultRootWindow(xdisplay), False,
              SubstructureRedirectMask | SubstructureNotifyMask,
              &xclient);
+}
+
+void SetWindowType(::Window xwindow, const std::string& type) {
+  XDisplay* xdisplay = gfx::GetXDisplay();
+  std::string type_prefix = "_NET_WM_WINDOW_TYPE_";
+  ::Atom window_type = XInternAtom(
+      xdisplay, (type_prefix + StringToUpperASCII(type)).c_str(), False);
+  XChangeProperty(xdisplay, xwindow,
+                  XInternAtom(xdisplay, "_NET_WM_WINDOW_TYPE", False),
+                  XA_ATOM,
+                  32, PropModeReplace,
+                  reinterpret_cast<unsigned char*>(&window_type), 1);
 }
 
 }  // namespace atom

--- a/atom/browser/ui/x/x_window_utils.h
+++ b/atom/browser/ui/x/x_window_utils.h
@@ -9,6 +9,8 @@
 #include <X11/extensions/Xrandr.h>
 #include <X11/Xlib.h>
 
+#include <string>
+
 namespace atom {
 
 ::Atom GetAtom(const char* name);
@@ -16,6 +18,9 @@ namespace atom {
 // Sends a message to the x11 window manager, enabling or disabling the |state|
 // for _NET_WM_STATE.
 void SetWMSpecState(::Window xwindow, bool enabled, ::Atom state);
+
+// Sets the _NET_WM_WINDOW_TYPE of window.
+void SetWindowType(::Window xwindow, const std::string& type);
 
 }  // namespace atom
 

--- a/atom/common/options_switches.cc
+++ b/atom/common/options_switches.cc
@@ -72,6 +72,9 @@ const char kPreloadScript[] = "preload";
 // Whether the window should be transparent.
 const char kTransparent[] = "transparent";
 
+// Window type hint.
+const char kType[] = "type";
+
 // Web runtime features.
 const char kExperimentalFeatures[]       = "experimental-features";
 const char kExperimentalCanvasFeatures[] = "experimental-canvas-features";

--- a/atom/common/options_switches.h
+++ b/atom/common/options_switches.h
@@ -40,6 +40,7 @@ extern const char kEnablePlugins[];
 extern const char kGuestInstanceID[];
 extern const char kPreloadScript[];
 extern const char kTransparent[];
+extern const char kType[];
 
 extern const char kExperimentalFeatures[];
 extern const char kExperimentalCanvasFeatures[];

--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -68,6 +68,9 @@ You can also create a window without chrome by using
     no matter whether node integration is turned on for the window, and the path
     of `preload` script has to be absolute path.
   * `transparent` Boolean - Makes the window [transparent](frameless-window.md)
+  * `type` String - Specifies the type of the window, possible types are
+    `desktop`, `dock`, `toolbar`, `splash`, `notification`. This only works on
+    Linux.
   * `web-preferences` Object - Settings of web page's features
     * `javascript` Boolean
     * `web-security` Boolean


### PR DESCRIPTION
This PR adds a `type` option of `BrowserWindow`, which can be used to change `_NET_WM_WINDOW_TYPE` property of the underlying X Window.

Fixes #657.