### PR TITLE
Bundle all the .js files in asar archive

### DIFF
--- a/atom.gyp
+++ b/atom.gyp
@@ -625,40 +625,31 @@
     {
       'target_name': 'compile_coffee',
       'type': 'none',
-      'sources': [
-        '<@(coffee_sources)',
-      ],
-      'rules': [
+      'actions': [
         {
-          'rule_name': 'coffee',
-          'extension': 'coffee',
+          'action_name': 'compile_coffee',
+          'variables': {
+            'conditions': [
+              ['OS=="mac"', {
+                'resources_path': '<(PRODUCT_DIR)/<(product_name).app/Contents/Resources',
+              },{
+                'resources_path': '<(PRODUCT_DIR)/resources',
+              }],
+            ],
+          },
           'inputs': [
-            'tools/compile-coffee.py',
+            '<@(coffee_sources)',
           ],
-          'conditions': [
-            ['OS=="mac"', {
-              'outputs': [
-                '<(PRODUCT_DIR)/<(product_name).app/Contents/Resources/<(RULE_INPUT_DIRNAME)/<(RULE_INPUT_ROOT).js',
-              ],
-              'action': [
-                'python',
-                'tools/compile-coffee.py',
-                '<(RULE_INPUT_PATH)',
-                '<(PRODUCT_DIR)/<(product_name).app/Contents/Resources/<(RULE_INPUT_DIRNAME)/<(RULE_INPUT_ROOT).js',
-              ],
-            },{  # OS=="mac"
-              'outputs': [
-                '<(PRODUCT_DIR)/resources/<(RULE_INPUT_DIRNAME)/<(RULE_INPUT_ROOT).js',
-              ],
-              'action': [
-                'python',
-                'tools/compile-coffee.py',
-                '<(RULE_INPUT_PATH)',
-                '<(PRODUCT_DIR)/resources/<(RULE_INPUT_DIRNAME)/<(RULE_INPUT_ROOT).js',
-              ],
-            }],  # OS=="win" or OS=="linux"
+          'outputs': [
+            '<(resources_path)/atom.asar',
           ],
-        },
+          'action': [
+            'python',
+            'tools/coffee2asar.py',
+            '<@(_outputs)',
+            '<@(_inputs)',
+          ],
+        }
       ],
     },  # target compile_coffee
     {

--- a/atom/browser/lib/init.coffee
+++ b/atom/browser/lib/init.coffee
@@ -3,10 +3,6 @@ path   = require 'path'
 module = require 'module'
 util   = require 'util'
 
-# Expose information of current process.
-process.type = 'browser'
-process.resourcesPath = path.resolve process.argv[1], '..', '..', '..', '..'
-
 # We modified the original process.argv to let node.js load the atom.js,
 # we need to restore it here.
 process.argv.splice 1, 1

--- a/atom/browser/lib/init.coffee
+++ b/atom/browser/lib/init.coffee
@@ -21,7 +21,7 @@ process.argv.splice startMark, endMark - startMark + 1
 # Add browser/api/lib to require's search paths,
 # which contains javascript part of Atom's built-in libraries.
 globalPaths = module.globalPaths
-globalPaths.push path.join process.resourcesPath, 'atom', 'browser', 'api', 'lib'
+globalPaths.push path.resolve(__dirname, '..', 'api', 'lib')
 
 # Import common settings.
 require path.resolve(__dirname, '..', '..', 'common', 'lib', 'init')

--- a/atom/common/lib/init.coffee
+++ b/atom/common/lib/init.coffee
@@ -12,7 +12,7 @@ process.atomBinding = (name) ->
 
 # Add common/api/lib to module search paths.
 globalPaths = Module.globalPaths
-globalPaths.push path.join(process.resourcesPath, 'atom', 'common', 'api', 'lib')
+globalPaths.push path.resolve(__dirname, '..', 'api', 'lib')
 
 # setImmediate and process.nextTick makes use of uv_check and uv_prepare to
 # run the callbacks, however since we only run uv loop on requests, the

--- a/atom/common/node_bindings.cc
+++ b/atom/common/node_bindings.cc
@@ -169,7 +169,7 @@ node::Environment* NodeBindings::CreateEnvironment(
       exec_path.DirName().Append(FILE_PATH_LITERAL("resources"));
 #endif
   base::FilePath script_path =
-      resources_path.Append(FILE_PATH_LITERAL("atom"))
+      resources_path.Append(FILE_PATH_LITERAL("atom.asar"))
                     .Append(is_browser_ ? FILE_PATH_LITERAL("browser") :
                                           FILE_PATH_LITERAL("renderer"))
                     .Append(FILE_PATH_LITERAL("lib"))

--- a/atom/renderer/lib/init.coffee
+++ b/atom/renderer/lib/init.coffee
@@ -15,9 +15,10 @@ process.argv.splice 1, 1
 # Add renderer/api/lib to require's search paths, which contains javascript part
 # of Atom's built-in libraries.
 globalPaths = Module.globalPaths
-globalPaths.push path.join(process.resourcesPath, 'atom', 'renderer', 'api', 'lib')
+globalPaths.push path.resolve(__dirname, '..', 'api', 'lib')
 # And also app.
 globalPaths.push path.join(process.resourcesPath, 'app')
+globalPaths.push path.join(process.resourcesPath, 'app.asar')
 
 # Import common settings.
 require path.resolve(__dirname, '..', '..', 'common', 'lib', 'init')

--- a/atom/renderer/lib/init.coffee
+++ b/atom/renderer/lib/init.coffee
@@ -4,10 +4,6 @@ path    = require 'path'
 url     = require 'url'
 Module  = require 'module'
 
-# Expose information of current process.
-process.type = 'renderer'
-process.resourcesPath = path.resolve process.argv[1], '..', '..', '..', '..'
-
 # We modified the original process.argv to let node.js load the
 # atom-renderer.js, we need to restore it here.
 process.argv.splice 1, 1

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
 
   "devDependencies": {
     "atom-package-manager": "0.126.0",
+    "asar": "0.2.2",
     "coffee-script": "~1.7.1",
     "coffeelint": "~1.3.0",
     "request": "*"

--- a/tools/coffee2asar.py
+++ b/tools/coffee2asar.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python
+
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+
+
+SOURCE_ROOT = os.path.dirname(os.path.dirname(__file__))
+
+
+def main():
+  archive = sys.argv[1]
+  coffee_source_files = sys.argv[2:]
+
+  output_dir = tempfile.mkdtemp()
+  compile_coffee(coffee_source_files, output_dir)
+  call_asar(archive, output_dir)
+  shutil.rmtree(output_dir)
+
+
+def compile_coffee(coffee_source_files, output_dir):
+  for source_file in coffee_source_files:
+    output_filename = os.path.splitext(source_file)[0] + '.js'
+    output_path = os.path.join(output_dir, output_filename)
+    call_compile_coffee(source_file, output_path)
+
+
+def call_compile_coffee(source_file, output_filename):
+  compile_coffee = os.path.join(SOURCE_ROOT, 'tools', 'compile-coffee.py')
+  subprocess.check_call([sys.executable, compile_coffee, source_file,
+                         output_filename])
+
+
+def call_asar(archive, output_dir):
+  js_dir = os.path.join(output_dir, 'atom')
+  asar = os.path.join(SOURCE_ROOT, 'node_modules', 'asar', 'bin', 'asar')
+  subprocess.check_call([find_node(), asar, 'pack', js_dir, archive])
+
+
+def find_node():
+  WINDOWS_NODE_PATHs = [
+    'C:/Program Files (x86)/nodejs',
+    'C:/Program Files/nodejs',
+  ] + os.environ['PATH'].split(os.pathsep)
+
+  if sys.platform in ['win32', 'cygwin']:
+    for path in WINDOWS_NODE_PATHs:
+      full_path = os.path.join(path, 'node.exe')
+      if os.path.exists(full_path):
+        return full_path
+  return 'node'
+
+if __name__ == '__main__':
+  sys.exit(main())


### PR DESCRIPTION
This PR bundles all the files under `Atom.app/Contents/Resources/atom/*` into an asar archive, so the final distribution doesn't contain lots of `.js` files. It doesn't have other benefits though.

Fixes #716.