### PR TITLE
Implement FakeWindow.postMessage, window.opener.postMessage and window.closed flag for popup windows

### DIFF
--- a/atom/browser/lib/guest-window-manager.coffee
+++ b/atom/browser/lib/guest-window-manager.coffee
@@ -17,9 +17,11 @@ createGuest = (embedder, url, frameName, options) ->
   # guest is closed by user then we should prevent |embedder| from double
   # closing guest.
   closedByEmbedder = ->
+    embedder.send 'ATOM_SHELL_GUEST_WINDOW_MANAGER_WINDOW_CLOSED', guest.id
     guest.removeListener 'closed', closedByUser
     guest.destroy() unless guest.isClosed()
   closedByUser = ->
+    embedder.send 'ATOM_SHELL_GUEST_WINDOW_MANAGER_WINDOW_CLOSED', guest.id
     embedder.removeListener 'render-view-deleted', closedByEmbedder
   embedder.once 'render-view-deleted', closedByEmbedder
   guest.once 'closed', closedByUser
@@ -29,6 +31,10 @@ createGuest = (embedder, url, frameName, options) ->
     guest.frameName = frameName
     guest.once 'closed', ->
       delete frameToGuest[frameName]
+
+  ipc.on 'ATOM_SHELL_GUEST_WINDOW_MANAGER_WINDOW_OPENER_POSTMESSAGE', (event, method, args...) ->
+    if embedder.getUrl().indexOf(args[1]) is 0 or args[1] is '*'
+      embedder.send 'ATOM_SHELL_GUEST_WINDOW_MANAGER_WINDOW_POSTMESSAGE', args[0], args[1];
 
   guest.id
 
@@ -48,6 +54,12 @@ ipc.on 'ATOM_SHELL_GUEST_WINDOW_MANAGER_WINDOW_CLOSE', (event, guestId) ->
 ipc.on 'ATOM_SHELL_GUEST_WINDOW_MANAGER_WINDOW_METHOD', (event, guestId, method, args...) ->
   return unless BrowserWindow.windows.has guestId
   BrowserWindow.windows.get(guestId)[method] args...
+
+ipc.on 'ATOM_SHELL_GUEST_WINDOW_MANAGER_WINDOW_POSTMESSAGE', (event, guestId, method, args...) ->
+  return unless BrowserWindow.windows.has guestId
+  window = BrowserWindow.windows.get(guestId)
+  if window.getUrl().indexOf(args[1]) is 0 or args[1] is '*'
+    window.send 'ATOM_SHELL_GUEST_WINDOW_MANAGER_WINDOW_POSTMESSAGE', args[0], args[1]
 
 ipc.on 'ATOM_SHELL_GUEST_WINDOW_MANAGER_WEB_CONTENTS_METHOD', (event, guestId, method, args...) ->
   return unless BrowserWindow.windows.has guestId

--- a/atom/browser/lib/guest-window-manager.coffee
+++ b/atom/browser/lib/guest-window-manager.coffee
@@ -32,9 +32,9 @@ createGuest = (embedder, url, frameName, options) ->
     guest.once 'closed', ->
       delete frameToGuest[frameName]
 
-  ipc.on 'ATOM_SHELL_GUEST_WINDOW_MANAGER_WINDOW_OPENER_POSTMESSAGE', (event, method, args...) ->
-    if embedder.getUrl().indexOf(args[1]) is 0 or args[1] is '*'
-      embedder.send 'ATOM_SHELL_GUEST_WINDOW_MANAGER_WINDOW_POSTMESSAGE', args[0], args[1]
+  ipc.on 'ATOM_SHELL_GUEST_WINDOW_MANAGER_WINDOW_OPENER_POSTMESSAGE', (event, message, targetOrigin) ->
+    if embedder.getUrl().indexOf(targetOrigin) is 0 or targetOrigin is '*'
+      embedder.send 'ATOM_SHELL_GUEST_WINDOW_MANAGER_WINDOW_POSTMESSAGE', message, targetOrigin
 
   guest.id
 
@@ -55,11 +55,11 @@ ipc.on 'ATOM_SHELL_GUEST_WINDOW_MANAGER_WINDOW_METHOD', (event, guestId, method,
   return unless BrowserWindow.windows.has guestId
   BrowserWindow.windows.get(guestId)[method] args...
 
-ipc.on 'ATOM_SHELL_GUEST_WINDOW_MANAGER_WINDOW_POSTMESSAGE', (event, guestId, method, args...) ->
+ipc.on 'ATOM_SHELL_GUEST_WINDOW_MANAGER_WINDOW_POSTMESSAGE', (event, guestId, message, targetOrigin) ->
   return unless BrowserWindow.windows.has guestId
   window = BrowserWindow.windows.get(guestId)
-  if window.getUrl().indexOf(args[1]) is 0 or args[1] is '*'
-    window.send 'ATOM_SHELL_GUEST_WINDOW_MANAGER_WINDOW_POSTMESSAGE', args[0], args[1]
+  if window.getUrl().indexOf(targetOrigin) is 0 or targetOrigin is '*'
+    window.send 'ATOM_SHELL_GUEST_WINDOW_MANAGER_WINDOW_POSTMESSAGE', message, targetOrigin
 
 ipc.on 'ATOM_SHELL_GUEST_WINDOW_MANAGER_WEB_CONTENTS_METHOD', (event, guestId, method, args...) ->
   return unless BrowserWindow.windows.has guestId

--- a/atom/browser/lib/guest-window-manager.coffee
+++ b/atom/browser/lib/guest-window-manager.coffee
@@ -34,7 +34,7 @@ createGuest = (embedder, url, frameName, options) ->
 
   ipc.on 'ATOM_SHELL_GUEST_WINDOW_MANAGER_WINDOW_OPENER_POSTMESSAGE', (event, method, args...) ->
     if embedder.getUrl().indexOf(args[1]) is 0 or args[1] is '*'
-      embedder.send 'ATOM_SHELL_GUEST_WINDOW_MANAGER_WINDOW_POSTMESSAGE', args[0], args[1];
+      embedder.send 'ATOM_SHELL_GUEST_WINDOW_MANAGER_WINDOW_POSTMESSAGE', args[0], args[1]
 
   guest.id
 

--- a/atom/renderer/lib/override.coffee
+++ b/atom/renderer/lib/override.coffee
@@ -5,11 +5,9 @@ remote = require 'remote'
 # Window object returned by "window.open".
 class FakeWindow
   constructor: (@guestId) ->
-    that = this
-
-    ipc.on 'ATOM_SHELL_GUEST_WINDOW_MANAGER_WINDOW_CLOSED', (guestId) ->
-      if guestId is that.guestId
-        that.closed = true
+    ipc.on 'ATOM_SHELL_GUEST_WINDOW_MANAGER_WINDOW_CLOSED', (guestId) =>
+      if guestId is @guestId
+        @closed = true
 
   close: ->
     ipc.send 'ATOM_SHELL_GUEST_WINDOW_MANAGER_WINDOW_CLOSE', @guestId
@@ -20,8 +18,8 @@ class FakeWindow
   blur: ->
     ipc.send 'ATOM_SHELL_GUEST_WINDOW_MANAGER_WINDOW_METHOD', @guestId, 'blur'
 
-  postMessage: (args...) ->
-    ipc.send 'ATOM_SHELL_GUEST_WINDOW_MANAGER_WINDOW_POSTMESSAGE', @guestId, 'postMessage', args[0], args[1]
+  postMessage: (message, targetOrigin) ->
+    ipc.send 'ATOM_SHELL_GUEST_WINDOW_MANAGER_WINDOW_POSTMESSAGE', @guestId, message, targetOrigin
 
   eval: (args...) ->
     ipc.send 'ATOM_SHELL_GUEST_WINDOW_MANAGER_WEB_CONTENTS_METHOD', @guestId, 'executeJavaScript', args...
@@ -73,8 +71,8 @@ window.prompt = ->
   throw new Error('prompt() is and will not be supported in atom-shell.')
 
 window.opener =
-  postMessage: (args...) ->
-    ipc.send 'ATOM_SHELL_GUEST_WINDOW_MANAGER_WINDOW_OPENER_POSTMESSAGE', 'postMessage', args[0], args[1]
+  postMessage: (message, targetOrigin) ->
+    ipc.send 'ATOM_SHELL_GUEST_WINDOW_MANAGER_WINDOW_OPENER_POSTMESSAGE', message, targetOrigin
 
-ipc.on 'ATOM_SHELL_GUEST_WINDOW_MANAGER_WINDOW_POSTMESSAGE', (data, origin) ->
-  window.postMessage(data, origin)
+ipc.on 'ATOM_SHELL_GUEST_WINDOW_MANAGER_WINDOW_POSTMESSAGE', (message, targetOrigin) ->
+  window.postMessage(message, targetOrigin)

--- a/atom/renderer/lib/override.coffee
+++ b/atom/renderer/lib/override.coffee
@@ -21,7 +21,7 @@ class FakeWindow
     ipc.send 'ATOM_SHELL_GUEST_WINDOW_MANAGER_WINDOW_METHOD', @guestId, 'blur'
 
   postMessage: (args...) ->
-    ipc.send 'ATOM_SHELL_GUEST_WINDOW_MANAGER_WINDOW_POSTMESSAGE', @guestId, 'postMessage', args[0], args[1];
+    ipc.send 'ATOM_SHELL_GUEST_WINDOW_MANAGER_WINDOW_POSTMESSAGE', @guestId, 'postMessage', args[0], args[1]
 
   eval: (args...) ->
     ipc.send 'ATOM_SHELL_GUEST_WINDOW_MANAGER_WEB_CONTENTS_METHOD', @guestId, 'executeJavaScript', args...

--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -641,9 +641,7 @@ Emitted when a redirect was received while requesting a resource.
 
 Emitted when the page requested to open a new window for `url`. It could be
 requested by `window.open` or an external link like `<a target='_blank'>`.
-
-By default a new `BrowserWindow` will be created for the `url`, and a proxy
-will be returned to `window.open` to let you have limited control of it.
+Check the next section [Handling Child Windows](#handlingchildwindows) for more information.
 
 Calling `event.preventDefault()` can prevent creating new windows.
 
@@ -844,3 +842,52 @@ app.on('ready', function() {
    is different from the handlers on browser side.
 2. There is no way to send synchronous messages from browser side to web pages,
    because it would be very easy to cause dead locks.
+
+## Handling Child Windows
+
+When the page contents request opening a new window, either by invoking
+`window.open` or by an external link such as `<a target='_blank'>`, by
+default a new `BrowserWindow` will be created for the `url`, and a proxy
+will be returned to `window.open` to let the page to have limited control over it.
+
+The proxy has some limited standard functionality implemented, which will help
+the page to interact with it. The following methods are avaialable:
+
+### Window.blur()
+
+Removes focus from the child window.
+
+### Window.close()
+
+Forcefully closes the child window without calling its unload event.
+
+### Window.closed
+
+Set to true after the child window gets closed.
+
+### Window.eval(code)
+
+* `code` String
+
+Evaluates the code in the child window.
+
+### Window.focus()
+
+Focuses the child window (brings the window to front).
+
+### Window.postMessage(message, targetOrigin)
+
+* `message` String
+* `targetOrigin` String
+
+Sends a message to the child window with the specified origin or "*" for no origin preference.
+
+In addition to these methods, the child window implements `window.opener` object with no properties
+and a single method:
+
+### window.opener.postMessage(message, targetOrigin)
+
+* `message` String
+* `targetOrigin` String
+
+Sends a message to the parent window with the specified origin or "*" for no origin preference.

--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -641,7 +641,7 @@ Emitted when a redirect was received while requesting a resource.
 
 Emitted when the page requested to open a new window for `url`. It could be
 requested by `window.open` or an external link like `<a target='_blank'>`.
-Check the next section [Handling Child Windows](#handlingchildwindows) for more information.
+Check the next section [Handling Child Windows](#handling-child-windows) for more information.
 
 Calling `event.preventDefault()` can prevent creating new windows.
 


### PR DESCRIPTION
PostMessage support will make the communication between window and popup easier.
Additionally window.closed flag is important for cleanup after popup closure.