### PR TITLE
Fix macro expansion issue for Windows

### DIFF
--- a/atom/common/node_bindings.cc
+++ b/atom/common/node_bindings.cc
@@ -178,7 +178,8 @@ node::Environment* NodeBindings::CreateEnvironment(
   base::FilePath resources_path = GetResourcesPath(command_line, is_browser_);
   base::FilePath script_path =
       resources_path.Append(FILE_PATH_LITERAL("atom.asar"))
-                    .Append(FILE_PATH_LITERAL(process_type))
+                    .Append(is_browser_ ? FILE_PATH_LITERAL("browser") :
+                                          FILE_PATH_LITERAL("renderer"))
                     .Append(FILE_PATH_LITERAL("lib"))
                     .Append(FILE_PATH_LITERAL("init.js"));
   std::string script_path_str = script_path.AsUTF8Unsafe();


### PR DESCRIPTION
The FILE_PATH_LITERAL macro is not safe to use with a variable on Windows.
It only works with actual string literals.
https://github.com/atom/atom-shell/commit/4834eed5204502038cd3003bf7b34b957f95e4dd#commitcomment-9755232