### PR TITLE
Fix window.open options parsing

### DIFF
--- a/atom/renderer/lib/override.coffee
+++ b/atom/renderer/lib/override.coffee
@@ -26,20 +26,24 @@ unless process.guestInstanceId?
 # Make the browser window or guest view emit "new-window" event.
 window.open = (url, frameName='', features='') ->
   options = {}
-  for feature in features.split ','
-    [name, value] = feature.split '='
+  ints = [ 'x', 'y', 'width', 'height', 'min-width', 'max-width', 'min-height', 'max-height', 'zoom-factor' ]
+  # Make sure to get rid of excessive whitespace in the property name
+  for feature in features.split /,\s*/
+    [name, value] = feature.split /\s*=/
     options[name] =
-      if value is 'yes'
+      if value is 'yes' or value is '1'
         true
-      else if value is 'no'
+      else if value is 'no' or value is '0'
         false
       else
         value
-  options.x ?= options.left
-  options.y ?= options.top
+  options.x ?= options.left if options.left
+  options.y ?= options.top if options.top
   options.title ?= name
   options.width ?= 800
   options.height ?= 600
+
+  (options[name] = parseInt(options[name], 10) if options[name]?) for name in ints
 
   guestId = ipc.sendSync 'ATOM_SHELL_GUEST_WINDOW_MANAGER_WINDOW_OPEN', url, frameName, options
   if guestId


### PR DESCRIPTION
Remove excessive whitespace (gets inserted in property names).
Avoid creating dummy properties if not needed.
Turn 1/0 to true/false, convert integer strings to numbers (fixes width/height).