### PR TITLE
Broken link in docs, api/synopsis

### DIFF
--- a/docs/api/synopsis.md
+++ b/docs/api/synopsis.md
@@ -2,7 +2,7 @@
 
 All [node.js's built-in modules](http://nodejs.org/api/) are available in
 atom-shell, and third-party node modules are fully supported too (including the
-[native modules](../tutorial/use-native-node-modules.md)).
+[native modules](../tutorial/using-native-node-modules.md)).
 
 Atom-shell also provides some extra built-in modules for developing native
 desktop applications. Some modules are only available on the browser side, some


### PR DESCRIPTION
Link to using-native-node-modules.md instead of use-native-node-modules. Filename changed with 268508764f25697d745fd40d0b63e096acb4ae7d