### PR TITLE
Prevent overflow on webview with height: 100%

### DIFF
--- a/atom/renderer/lib/web-view/web-view.coffee
+++ b/atom/renderer/lib/web-view/web-view.coffee
@@ -186,6 +186,7 @@ registerBrowserPluginElement = ->
     @setAttribute 'type', 'application/browser-plugin'
     @setAttribute 'id', 'browser-plugin-' + getNextId()
     # The <object> node fills in the <webview> container.
+    @style.display = 'block'
     @style.width = '100%'
     @style.height = '100%'
 


### PR DESCRIPTION
Without this, the object element gets displayed `inline` which in chromium means that it slightly exceeds it's bounds. Unfortunately there's no nice way to mitigate this issue as I can't find a way to get extra css into this intermediate page. However, forcing a block display solves the issue.