### PR TITLE
App Before-Quit Event

### DIFF
--- a/atom/browser/api/atom_api_app.cc
+++ b/atom/browser/api/atom_api_app.cc
@@ -131,6 +131,10 @@ App::~App() {
   Browser::Get()->RemoveObserver(this);
 }
 
+void App::OnBeforeQuit(bool* prevent_default) {
+  *prevent_default = Emit("before-quit");
+}
+
 void App::OnWillQuit(bool* prevent_default) {
   *prevent_default = Emit("will-quit");
 }

--- a/atom/browser/api/atom_api_app.h
+++ b/atom/browser/api/atom_api_app.h
@@ -38,6 +38,7 @@ class App : public mate::EventEmitter,
   virtual ~App();
 
   // BrowserObserver:
+  void OnBeforeQuit(bool* prevent_default) override;
   void OnWillQuit(bool* prevent_default) override;
   void OnWindowAllClosed() override;
   void OnQuit() override;

--- a/atom/browser/browser.cc
+++ b/atom/browser/browser.cc
@@ -118,7 +118,9 @@ void Browser::NotifyAndShutdown() {
 
 bool Browser::HandleBeforeQuit() {
   bool prevent_default = false;
-  FOR_EACH_OBSERVER(BrowserObserver, observers_, OnBeforeQuit(&prevent_default));
+  FOR_EACH_OBSERVER(BrowserObserver,
+                    observers_,
+                    OnBeforeQuit(&prevent_default));
 
   return !prevent_default;
 }

--- a/atom/browser/browser.cc
+++ b/atom/browser/browser.cc
@@ -28,7 +28,9 @@ Browser* Browser::Get() {
 }
 
 void Browser::Quit() {
-  is_quiting_ = true;
+  is_quiting_ = HandleBeforeQuit();
+  if (!is_quiting_)
+    return;
 
   atom::WindowList* window_list = atom::WindowList::GetInstance();
   if (window_list->size() == 0)
@@ -112,6 +114,13 @@ void Browser::NotifyAndShutdown() {
   }
 
   Shutdown();
+}
+
+bool Browser::HandleBeforeQuit() {
+  bool prevent_default = false;
+  FOR_EACH_OBSERVER(BrowserObserver, observers_, OnBeforeQuit(&prevent_default));
+
+  return !prevent_default;
 }
 
 void Browser::OnWindowCloseCancelled(NativeWindow* window) {

--- a/atom/browser/browser.h
+++ b/atom/browser/browser.h
@@ -136,6 +136,9 @@ class Browser : public WindowListObserver {
   // Send the will-quit message and then shutdown the application.
   void NotifyAndShutdown();
 
+  // Send the before-quit message and start closing windows.
+  bool HandleBeforeQuit();
+
   bool is_quiting_;
 
  private:

--- a/atom/browser/browser_observer.h
+++ b/atom/browser/browser_observer.h
@@ -11,6 +11,9 @@ namespace atom {
 
 class BrowserObserver {
  public:
+  // The browser is about to close all windows.
+  virtual void OnBeforeQuit(bool* prevent_default) {}
+  
   // The browser has closed all windows and will quit.
   virtual void OnWillQuit(bool* prevent_default) {}
 

--- a/atom/browser/browser_observer.h
+++ b/atom/browser/browser_observer.h
@@ -13,7 +13,7 @@ class BrowserObserver {
  public:
   // The browser is about to close all windows.
   virtual void OnBeforeQuit(bool* prevent_default) {}
-  
+
   // The browser has closed all windows and will quit.
   virtual void OnWillQuit(bool* prevent_default) {}
 

--- a/docs/api/app.md
+++ b/docs/api/app.md
@@ -34,6 +34,14 @@ user pressed `Cmd + Q`, or the developer called `app.quit()`, atom-shell would
 first try to close all windows and then emit the `will-quit` event, and in
 this case the `window-all-closed` would not be emitted.
 
+## Event: before-quit
+
+* `event` Event
+
+Emitted before the application starts closing its windows.
+Calling `event.preventDefault()` will prevent the default behaviour, which is
+terminating the application.
+
 ## Event: will-quit
 
 * `event` Event
@@ -78,9 +86,9 @@ click on the application's dock icon.
 
 ## app.quit()
 
-Try to close all windows. If all windows are successfully closed, the
-`will-quit` event will be emitted and by default the application would be
-terminated.
+Try to close all windows. The `before-quit` event will first be emitted. If all
+windows are successfully closed, the `will-quit` event will be emitted and by
+default the application would be terminated.
 
 This method guarantees all `beforeunload` and `unload` handlers are correctly
 executed. It is possible that a window cancels the quitting by returning


### PR DESCRIPTION
Emit a new `before-quit` event at the start of `Browser::Quit`, which gives us a chance to cancel before any windows are closed.
This is an attempt to solve https://github.com/atom/atom-shell/issues/444.