### PR TITLE
using WebContentsObserver::NavigationEntryCommitted to set virtualurl

### DIFF
--- a/atom/browser/api/atom_api_web_contents.cc
+++ b/atom/browser/api/atom_api_web_contents.cc
@@ -16,6 +16,7 @@
 #include "base/strings/utf_string_conversions.h"
 #include "brightray/browser/inspectable_web_contents.h"
 #include "content/public/browser/navigation_details.h"
+#include "content/public/browser/navigation_entry.h"
 #include "content/public/browser/render_frame_host.h"
 #include "content/public/browser/render_process_host.h"
 #include "content/public/browser/render_view_host.h"
@@ -264,6 +265,15 @@ void WebContents::WebContentsDestroyed() {
   Emit("destroyed");
 }
 
+void WebContents::NavigationEntryCommitted(
+    const content::LoadCommittedDetails& load_details) {
+  content::NavigationEntry* entry = load_details.entry;
+  web_contents()
+      ->GetController()
+      .GetLastCommittedEntry()
+      ->SetVirtualURL(entry->GetOriginalRequestURL());
+}
+
 void WebContents::DidAttach(int guest_proxy_routing_id) {
   Emit("did-attach");
 }
@@ -323,7 +333,10 @@ void WebContents::LoadURL(const GURL& url, const mate::Dictionary& options) {
 }
 
 GURL WebContents::GetURL() const {
-  return web_contents()->GetURL();
+  return web_contents()
+                ->GetController()
+                .GetLastCommittedEntry()
+                ->GetVirtualURL();
 }
 
 base::string16 WebContents::GetTitle() const {

--- a/atom/browser/api/atom_api_web_contents.h
+++ b/atom/browser/api/atom_api_web_contents.h
@@ -165,6 +165,8 @@ class WebContents : public mate::EventEmitter,
   bool OnMessageReceived(const IPC::Message& message) override;
   void RenderViewReady() override;
   void WebContentsDestroyed() override;
+  void NavigationEntryCommitted(
+      const content::LoadCommittedDetails& load_details) override;
 
   // content::BrowserPluginGuestDelegate:
   void DidAttach(int guest_proxy_routing_id) final;


### PR DESCRIPTION
Fixes #1116 . The problem was not `GetURL` ,apparently subframe transition urls were recorded in NavigationEntry as `about:blank` for `file://` . Tried changing params opton in LoadUrl with frame_ids, transition types etc but none helped. So for the moment this the best fix that works. If there is a better way let me know :) 
![screenshot from 2015-03-05 20 14 39](https://cloud.githubusercontent.com/assets/964386/6506898/4b16eeaa-c374-11e4-9131-a7413a057b6d.png)
