### PR TITLE
expand tilde in NSSavepanel SetDirectoryURL

### DIFF
--- a/atom/browser/ui/file_dialog_mac.mm
+++ b/atom/browser/ui/file_dialog_mac.mm
@@ -64,7 +64,8 @@ void SetupDialog(NSSavePanel* dialog,
   }
 
   if (default_dir)
-    [dialog setDirectoryURL:[NSURL fileURLWithPath:default_dir]];
+    [dialog setDirectoryURL:[NSURL fileURLWithPath:[
+        default_dir stringByExpandingTildeInPath]]];
   if (default_filename)
     [dialog setNameFieldStringValue:default_filename];
 


### PR DESCRIPTION
fix for #1212 on osx , http://stackoverflow.com/questions/7819922/nsopenpanels-setdirectoryurl-doesnt-work-on-lion . Dont have access to a windows machine to figure out what the cause there might be.