### PR TITLE
Linux binary name is 'atom-shell' not 'atom'

### DIFF
--- a/docs/tutorial/quick-start.md
+++ b/docs/tutorial/quick-start.md
@@ -138,7 +138,7 @@ $ .\atom-shell\atom.exe your-app\
 On Linux:
 
 ```bash
-$ ./atom-shell/atom your-app/
+$ ./atom-shell/atom-shell your-app/
 ```
 
 On OS X:


### PR DESCRIPTION
I installed atom-shell with: npm install atom-shell -g

The binary I have is : ./usr/bin/atom-shell

When would specifying the path ./atom-shell be appropriate?