### PR TITLE
define devToolsWebContents for use from remote module

### DIFF
--- a/atom/browser/api/lib/browser-window.coffee
+++ b/atom/browser/api/lib/browser-window.coffee
@@ -17,6 +17,7 @@ BrowserWindow::_init = ->
     @setMenu menu if menu?
 
   @webContents = @getWebContents()
+  @devToolsWebContents = null
   @webContents.once 'destroyed', => @webContents = null
 
   # Remember the window ID.


### PR DESCRIPTION
Fixes #1186 , love the way remote lib has been written :) but is this variable needed when we already have `getDevToolsWebContents` exposed ? Now if someone uses `window.getDevToolsWebContents` it wont have the emitters attached but still return the right contents, so would it be good to return `devToolsContents` from there instead of `openDevTools` ?