### PR TITLE
rename node-webkit to NW.js in development docs

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -55,7 +55,7 @@ Modules for both sides:
 
 * [Coding style](development/coding-style.md)
 * [Source code directory structure](development/source-code-directory-structure.md)
-* [Technical differences to node-webkit](development/atom-shell-vs-node-webkit.md)
+* [Technical differences to NW.js](development/atom-shell-vs-nwjs.md)
 * [Build instructions (Mac)](development/build-instructions-mac.md)
 * [Build instructions (Windows)](development/build-instructions-windows.md)
 * [Build instructions (Linux)](development/build-instructions-linux.md)

--- a/docs/README.md
+++ b/docs/README.md
@@ -55,7 +55,7 @@ Modules for both sides:
 
 * [Coding style](development/coding-style.md)
 * [Source code directory structure](development/source-code-directory-structure.md)
-* [Technical differences to NW.js](development/atom-shell-vs-nwjs.md)
+* [Technical differences to NW.js (formerly node-webkit)](development/atom-shell-vs-node-webkit.md)
 * [Build instructions (Mac)](development/build-instructions-mac.md)
 * [Build instructions (Windows)](development/build-instructions-windows.md)
 * [Build instructions (Linux)](development/build-instructions-linux.md)

--- a/docs/development/atom-shell-vs-node-webkit.md
+++ b/docs/development/atom-shell-vs-node-webkit.md
@@ -1,4 +1,4 @@
-# Technical differences to NW.js
+# Technical differences to NW.js (formerly node-webkit)
 
 Like NW.js, atom-shell provides a platform to write desktop applications
 with JavaScript and HTML, and has Node integration to grant access to low level

--- a/docs/development/atom-shell-vs-nwjs.md
+++ b/docs/development/atom-shell-vs-nwjs.md
@@ -1,15 +1,15 @@
-# Technical differences to Node-Webkit
+# Technical differences to NW.js
 
-Like Node-Webkit, atom-shell provides a platform to write desktop applications
+Like NW.js, atom-shell provides a platform to write desktop applications
 with JavaScript and HTML, and has Node integration to grant access to low level
 system in web pages.
 
 But there are also fundamental differences between the two projects that make
-atom-shell a completely separate product from Node-Webkit:
+atom-shell a completely separate product from NW.js:
 
 **1. Entry of application**
 
-In Node-Webkit, the main entry of an application is a web page, you specify a
+In NW.js, the main entry of an application is a web page, you specify a
 main page in the `package.json` and it would be opened in a browser window as
 the application's main window.
 
@@ -32,16 +32,16 @@ need a powerful machine to build atom-shell.
 
 **3. Node integration**
 
-In Node-Webkit, the Node integration in web pages requires patching Chromium to
+In NW.js, the Node integration in web pages requires patching Chromium to
 work, while in atom-shell we chose a different way to integrate libuv loop to
 each platform's message loop to avoid hacking Chromium, see the
 [`node_bindings`](../../atom/common/) code for how that was done.
 
 **4. Multi-context**
 
-If you are an experienced Node-Webkit user, you should be familiar with the
+If you are an experienced NW.js user, you should be familiar with the
 concept of Node context and web context, these concepts were invented because
-of how the Node-Webkit was implemented.
+of how the NW.js was implemented.
 
 By using the [multi-context](http://strongloop.com/strongblog/whats-new-node-js-v0-12-multiple-context-execution/)
 feature of Node, atom-shell doesn't introduce a new JavaScript context in web


### PR DESCRIPTION
Replaces all occurences of node-webkit with NW.js in the development docs.