### PR TITLE
Add check for root in script/bootstrap.py

### DIFF
--- a/script/bootstrap.py
+++ b/script/bootstrap.py
@@ -16,10 +16,12 @@ NPM = 'npm.cmd' if sys.platform in ['win32', 'cygwin'] else 'npm'
 
 
 def main():
-  check_root()
   os.chdir(SOURCE_ROOT)
 
   args = parse_args()
+  if (args.yes is False and
+      sys.platform not in ('win32', 'cygwin')):
+    check_root()
   if args.verbose:
     enable_verbose_mode()
   if sys.platform == 'cygwin':
@@ -47,6 +49,10 @@ def parse_args():
   parser.add_argument('-v', '--verbose',
                       action='store_true',
                       help='Prints the output of the subprocesses')
+  parser.add_argument('-y', '--yes', '--assume-yes',
+                      action='store_true',
+                      help='Run non-interactively by assuming "yes" to all ' \
+                           'prompts.')
   return parser.parse_args()
 
 def check_root():

--- a/script/bootstrap.py
+++ b/script/bootstrap.py
@@ -16,6 +16,7 @@ NPM = 'npm.cmd' if sys.platform in ['win32', 'cygwin'] else 'npm'
 
 
 def main():
+  check_root()
   os.chdir(SOURCE_ROOT)
 
   args = parse_args()
@@ -47,6 +48,13 @@ def parse_args():
                       action='store_true',
                       help='Prints the output of the subprocesses')
   return parser.parse_args()
+
+def check_root():
+  if os.geteuid() == 0:
+    print "We suggest not running this as root, unless you're really sure."
+    choice = raw_input("Do you want to continue? [y/N]: ")
+    if choice not in ('y', 'Y'):
+      sys.exit(0)
 
 
 def update_submodules():


### PR DESCRIPTION
I felt that this little prompt might make things a little more user friendly, and help users avoid potential future problems.

I'm not sure what `os.geteuid()` will do on Windows, and doing a little bit of research leads me to believe that it may cause the Python interpreter to complain, so the check for root is ignored on Windows. This may be good to look into a little further if someone wants to modify the platform checks.