### PR TITLE
implemetation of AtomCommandline to preserve args

### DIFF
--- a/atom.gyp
+++ b/atom.gyp
@@ -62,6 +62,8 @@
     'lib_sources': [
       'atom/app/atom_content_client.cc',
       'atom/app/atom_content_client.h',
+      'atom/app/atom_main_args.cc',
+      'atom/app/atom_main_args.h',
       'atom/app/atom_main_delegate.cc',
       'atom/app/atom_main_delegate.h',
       'atom/app/atom_main_delegate_mac.mm',

--- a/atom/app/atom_library_main.mm
+++ b/atom/app/atom_library_main.mm
@@ -4,6 +4,7 @@
 
 #include "atom/app/atom_library_main.h"
 
+#include "atom/app/atom_main_args.h"
 #include "atom/app/atom_main_delegate.h"
 #include "atom/app/node_main.h"
 #include "base/at_exit.h"
@@ -18,6 +19,7 @@ int AtomMain(int argc, const char* argv[]) {
   content::ContentMainParams params(&delegate);
   params.argc = argc;
   params.argv = argv;
+  atom::AtomCommandLine::Init(argc, argv);
   return content::ContentMain(params);
 }
 

--- a/atom/app/atom_main_args.cc
+++ b/atom/app/atom_main_args.cc
@@ -1,0 +1,18 @@
+// Copyright (c) 2013 GitHub, Inc.
+// Use of this source code is governed by the MIT license that can be
+// found in the LICENSE file.
+
+#include "atom/app/atom_main_args.h"
+
+namespace atom {
+
+  void AtomCommandLine::Init(int argc,
+          const char* const* argv) {
+    for (int i = 0; i < argc; ++i) {
+      argv_.push_back(argv[i]);
+    }
+  }
+
+  std::vector<std::string> AtomCommandLine::argv_;
+
+}  // namespace atom

--- a/atom/app/atom_main_args.h
+++ b/atom/app/atom_main_args.h
@@ -1,0 +1,28 @@
+// Copyright (c) 2015 GitHub, Inc.
+// Use of this source code is governed by the MIT license that can be
+// found in the LICENSE file.
+
+#ifndef ATOM_APP_ATOM_MAIN_ARGS_H_
+#define ATOM_APP_ATOM_MAIN_ARGS_H_
+
+#include <string>
+#include <vector>
+
+#include "base/logging.h"
+
+namespace atom {
+
+class AtomCommandLine {
+ public:
+  static void Init(int argc, const char* const* argv);
+  static std::vector<std::string> argv() { return argv_; }
+
+ private:
+  static std::vector<std::string> argv_;
+
+  DISALLOW_COPY_AND_ASSIGN(AtomCommandLine);
+};
+
+}  // namespace atom
+
+#endif  // ATOM_APP_ATOM_MAIN_ARGS_H_

--- a/atom/browser/lib/init.coffee
+++ b/atom/browser/lib/init.coffee
@@ -7,13 +7,6 @@ util   = require 'util'
 # we need to restore it here.
 process.argv.splice 1, 1
 
-# Pick out switches appended by atom-shell.
-startMark = process.argv.indexOf '--atom-shell-switches-start'
-endMark = process.argv.indexOf '--atom-shell-switches-end'
-# And --force-device-scale-factor on Linux.
-endMark++ if process.platform is 'linux'
-process.argv.splice startMark, endMark - startMark + 1
-
 # Add browser/api/lib to require's search paths,
 # which contains javascript part of Atom's built-in libraries.
 globalPaths = module.globalPaths

--- a/atom/common/node_bindings.cc
+++ b/atom/common/node_bindings.cc
@@ -7,6 +7,7 @@
 #include <string>
 #include <vector>
 
+#include "atom/app/atom_main_args.h"
 #include "atom/common/native_mate_converters/file_path_converter.h"
 #include "base/command_line.h"
 #include "base/base_paths.h"
@@ -97,21 +98,11 @@ void UvNoOp(uv_async_t* handle) {
 scoped_ptr<const char*[]> StringVectorToArgArray(
     const std::vector<std::string>& vector) {
   scoped_ptr<const char*[]> array(new const char*[vector.size()]);
-  for (size_t i = 0; i < vector.size(); ++i)
+  for (size_t i = 0; i < vector.size(); ++i) {
     array[i] = vector[i].c_str();
+  }
   return array.Pass();
 }
-
-#if defined(OS_WIN)
-std::vector<std::string> String16VectorToStringVector(
-    const std::vector<base::string16>& vector) {
-  std::vector<std::string> utf8_vector;
-  utf8_vector.reserve(vector.size());
-  for (size_t i = 0; i < vector.size(); ++i)
-    utf8_vector.push_back(base::UTF16ToUTF8(vector[i]));
-  return utf8_vector;
-}
-#endif
 
 base::FilePath GetResourcesPath(base::CommandLine* command_line,
                                 bool is_browser) {
@@ -167,13 +158,8 @@ void NodeBindings::Initialize() {
 
 node::Environment* NodeBindings::CreateEnvironment(
     v8::Handle<v8::Context> context) {
+  auto args = AtomCommandLine::argv();
   auto command_line = base::CommandLine::ForCurrentProcess();
-  std::vector<std::string> args =
-#if defined(OS_WIN)
-      String16VectorToStringVector(command_line->argv());
-#else
-      command_line->argv();
-#endif
 
   // Feed node the path to initialization script.
   base::FilePath::StringType process_type = is_browser_ ?

--- a/spec/api-browser-window-spec.coffee
+++ b/spec/api-browser-window-spec.coffee
@@ -5,7 +5,7 @@ remote = require 'remote'
 
 BrowserWindow = remote.require 'browser-window'
 
-isCI = remote.process.argv[1] == '--ci'
+isCI = remote.process.argv[2] == '--ci'
 
 describe 'browser-window module', ->
   fixtures = path.resolve __dirname, 'fixtures'

--- a/spec/fixtures/module/process_args.js
+++ b/spec/fixtures/module/process_args.js
@@ -1,0 +1,4 @@
+process.on('message', function() {
+  process.send(process.argv);
+  process.exit(0);
+});

--- a/spec/node-spec.coffee
+++ b/spec/node-spec.coffee
@@ -17,6 +17,14 @@ describe 'node feature', ->
           done()
         child.send 'message'
 
+      it 'preserves args', (done) ->
+        args = ['--expose_gc', '-test', '1']
+        child = child_process.fork path.join(fixtures, 'module', 'process_args.js'), args
+        child.on 'message', (msg) ->
+          assert.deepEqual args, msg.slice(2)
+          done()
+        child.send 'message'
+
       it 'works in forked process', (done) ->
         child = child_process.fork path.join(fixtures, 'module', 'fork_ping.js')
         child.on 'message', (msg) ->

--- a/spec/static/index.html
+++ b/spec/static/index.html
@@ -15,7 +15,7 @@
 
   // Check if we are running in CI.
   var argv = require('remote').process.argv;
-  var isCi = argv[1] == '--ci';
+  var isCi = argv[2] == '--ci';
 
   if (!isCi) {
     var win = require('remote').getCurrentWindow();

--- a/spec/static/main.js
+++ b/spec/static/main.js
@@ -33,7 +33,7 @@ ipc.on('echo', function(event, msg) {
   event.returnValue = msg;
 });
 
-if (process.argv[1] == '--ci') {
+if (process.argv[2] == '--ci') {
   process.removeAllListeners('uncaughtException');
   process.on('uncaughtException', function(error) {
     console.error(error, error.stack);


### PR DESCRIPTION
Inital work for #1248 . @zcbenz If its desirable to have our own commandline class , then i can implement other methods from `base::commandline` for our needs and eliminate its usage. If this is too heavy for a trivial stuff, feel free to close it. would love to hear any better approaches :)

EDIT: sorry didnt mean eliminate `base::commandLine` but just `atomCommandLine` will wrap around it, so all commandLine calls to base will happen through this new class.