### PR TITLE
Bring back the "subpixel-font-scaling" option

### DIFF
--- a/atom/browser/native_window.cc
+++ b/atom/browser/native_window.cc
@@ -77,6 +77,7 @@ namespace {
 const char* kWebRuntimeFeatures[] = {
   switches::kExperimentalFeatures,
   switches::kExperimentalCanvasFeatures,
+  switches::kSubpixelFontScaling,
   switches::kOverlayScrollbars,
   switches::kOverlayFullscreenVideo,
   switches::kSharedWorker,

--- a/atom/common/options_switches.cc
+++ b/atom/common/options_switches.cc
@@ -78,6 +78,7 @@ const char kType[] = "type";
 // Web runtime features.
 const char kExperimentalFeatures[]       = "experimental-features";
 const char kExperimentalCanvasFeatures[] = "experimental-canvas-features";
+const char kSubpixelFontScaling[]        = "subpixel-font-scaling";
 const char kOverlayScrollbars[]          = "overlay-scrollbars";
 const char kOverlayFullscreenVideo[]     = "overlay-fullscreen-video";
 const char kSharedWorker[]               = "shared-worker";

--- a/atom/common/options_switches.h
+++ b/atom/common/options_switches.h
@@ -44,6 +44,7 @@ extern const char kType[];
 
 extern const char kExperimentalFeatures[];
 extern const char kExperimentalCanvasFeatures[];
+extern const char kSubpixelFontScaling[];
 extern const char kOverlayScrollbars[];
 extern const char kOverlayFullscreenVideo[];
 extern const char kSharedWorker[];

--- a/atom/renderer/atom_renderer_client.cc
+++ b/atom/renderer/atom_renderer_client.cc
@@ -168,6 +168,8 @@ void AtomRendererClient::EnableWebRuntimeFeatures() {
     blink::WebRuntimeFeatures::enableExperimentalFeatures(b);
   if (IsSwitchEnabled(command_line, switches::kExperimentalCanvasFeatures, &b))
     blink::WebRuntimeFeatures::enableExperimentalCanvasFeatures(b);
+  if (IsSwitchEnabled(command_line, switches::kSubpixelFontScaling, &b))
+    blink::WebRuntimeFeatures::enableSubpixelFontScaling(b);
   if (IsSwitchEnabled(command_line, switches::kOverlayScrollbars, &b))
     blink::WebRuntimeFeatures::enableOverlayScrollbars(b);
   if (IsSwitchEnabled(command_line, switches::kOverlayFullscreenVideo, &b))

--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -88,6 +88,7 @@ You can also create a window without chrome by using
       under current working directory.
     * `experimental-features` Boolean
     * `experimental-canvas-features` Boolean
+    * `subpixel-font-scaling` Boolean
     * `overlay-scrollbars` Boolean
     * `overlay-fullscreen-video` Boolean
     * `shared-worker` Boolean

--- a/script/lib/config.py
+++ b/script/lib/config.py
@@ -4,7 +4,7 @@ import platform
 import sys
 
 BASE_URL = 'http://gh-contractor-zcbenz.s3.amazonaws.com/libchromiumcontent'
-LIBCHROMIUMCONTENT_COMMIT = '78ddaee2158886da53d0801db572be38230fd814'
+LIBCHROMIUMCONTENT_COMMIT = '26dd65a62e35aa98b25c10cbfc00f1a621fd4c4b'
 
 ARCH = {
     'cygwin': '32bit',


### PR DESCRIPTION
This option is still needed by Atom, so we patched Chromium to bring it back until we have a workaround in Atom.