### PR TITLE
added acceptsFirstMouse for controlRegionView

### DIFF
--- a/atom/browser/native_window_mac.mm
+++ b/atom/browser/native_window_mac.mm
@@ -243,6 +243,10 @@ static const CGFloat kAtomWindowCornerRadius = 4.0;
   shellWindow_->HandleMouseEvent(event);
 }
 
+- (BOOL)acceptsFirstMouse:(NSEvent*)event {
+  return YES;
+}
+
 @end
 
 @interface AtomProgressBar : NSProgressIndicator


### PR DESCRIPTION
fixes #1286 , but should this be a default behaviour or configurable one ?

hmm,  i dont seem to find a reason to not make this default behaviour for a draggable region in frameless window.