### PR TITLE
[doc]: fix when to use protocol module

### DIFF
--- a/docs/api/protocol.md
+++ b/docs/api/protocol.md
@@ -10,7 +10,7 @@ An example of implementing a protocol that has the same effect with the
 var app = require('app'),
     path = require('path');
 
-app.on('will-finish-launching', function() {
+app.on('ready', function() {
     var protocol = require('protocol');
     protocol.registerProtocol('atom', function(request) {
       var url = request.url.substr(7)
@@ -19,7 +19,7 @@ app.on('will-finish-launching', function() {
 });
 ```
 
-**Note:** This module can only be used after the `will-finish-launching` event
+**Note:** This module can only be used after the `ready` event
 was emitted.
 
 ## protocol.registerProtocol(scheme, handler)


### PR DESCRIPTION
app is made ready only here, https://github.com/atom/atom-shell/blob/38a871aa4b186e0850fdf773d659ba4f00c47a0a/atom/browser/browser.cc#L102 otherwise it would throw