### PR TITLE
allow setting loglevel

### DIFF
--- a/atom/app/atom_main_delegate.cc
+++ b/atom/app/atom_main_delegate.cc
@@ -27,8 +27,8 @@ AtomMainDelegate::~AtomMainDelegate() {
 
 bool AtomMainDelegate::BasicStartupComplete(int* exit_code) {
   // Disable logging out to debug.log on Windows
-#if defined(OS_WIN)
   logging::LoggingSettings settings;
+#if defined(OS_WIN)
 #if defined(DEBUG)
   settings.logging_dest = logging::LOG_TO_ALL;
   settings.log_file = L"debug.log";
@@ -37,8 +37,10 @@ bool AtomMainDelegate::BasicStartupComplete(int* exit_code) {
 #else
   settings.logging_dest = logging::LOG_TO_SYSTEM_DEBUG_LOG;
 #endif
-  logging::InitLogging(settings);
 #endif  // defined(OS_WIN)
+
+  // allows setting loglevel --v or --vmodule
+  logging::InitLogging(settings);
 
   // Logging with pid and timestamp.
   logging::SetLogItems(true, false, true, false);

--- a/docs/api/chrome-command-line-switches.md
+++ b/docs/api/chrome-command-line-switches.md
@@ -61,3 +61,30 @@ Like `--host-rules` but these `rules` only apply to the host resolver.
 ## --ignore-certificate-errors
 
 Ignore certificate related errors.
+
+## --v=`log_level`
+
+Gives the default maximal active V-logging level; 0 is the default.
+Normally positive values are used for V-logging levels.
+
+-1 to disable logs
+
+## --vmodule=`pattern`
+
+Gives the per-module maximal V-logging levels to override the value
+given by --v.  E.g. "my_module=2,foo*=3" would change the logging
+level for all code in source files "my_module.*" and "foo*.*"
+("-inl" suffixes are also disregarded for this matching).
+
+Any pattern containing a forward or backward slash will be tested
+against the whole pathname and not just the module.  E.g.,
+"*/foo/bar/*=2" would change the logging level for all code in
+source files under a "foo/bar" directory.
+
+For example to disable all chromium related logs and only enable
+your application logs
+
+```
+app.commandLine.appendSwitch('v', -1);
+app.commandLine.appendSwitch('vmodule', 'console=0');
+```


### PR DESCRIPTION
Fixes #1251 , there was provision in `logging::BaseInitLoggingImpl` to accept `--v or --vmodule` for setting loglevels. https://code.google.com/p/chromium/codesearch#chromium/src/base/base_switches.cc&sq=package:chromium&rcl=1427269032&l=33

using `--v=-1` will disable logs or perhaps use `--vmodule` for precise log control , should add documentation for the log levels ?