### PR TITLE
adding getNumDisplays and getActiveDisplay

### DIFF
--- a/atom/browser/api/atom_api_screen.h
+++ b/atom/browser/api/atom_api_screen.h
@@ -8,6 +8,7 @@
 #include <vector>
 
 #include "atom/browser/api/event_emitter.h"
+#include "content/public/browser/web_contents.h"
 #include "native_mate/handle.h"
 #include "ui/gfx/display_observer.h"
 
@@ -32,7 +33,9 @@ class Screen : public mate::EventEmitter,
 
   gfx::Point GetCursorScreenPoint();
   gfx::Display GetPrimaryDisplay();
+  gfx::Display GetActiveDisplay(content::WebContents* web_contents);
   std::vector<gfx::Display> GetAllDisplays();
+  int GetNumDisplays();
   gfx::Display GetDisplayNearestPoint(const gfx::Point& point);
   gfx::Display GetDisplayMatching(const gfx::Rect& match_rect);
 

--- a/docs/api/screen.md
+++ b/docs/api/screen.md
@@ -86,6 +86,14 @@ Returns the primary display.
 
 Returns an array of displays that are currently available.
 
+## screen.getActiveDisplay(webContents)
+
+Returns the current active display.
+
+## screen.getNumDisplays()
+
+Returns the number of displays available.
+
 ## screen.getDisplayNearestPoint(point)
 
 * `point` Object

--- a/spec/api-screen-spec.coffee
+++ b/spec/api-screen-spec.coffee
@@ -14,3 +14,8 @@ describe 'screen module', ->
       assert.equal typeof(display.scaleFactor), 'number'
       assert display.size.width > 0
       assert display.size.height > 0
+
+  describe 'screen.getNumDisplays()', ->
+    it 'returns the number of display objects', ->
+      count = screen.getNumDisplays()
+      assert.equal count, 1


### PR DESCRIPTION
Fixes #1293 , not happy about api for `getActiveDisplay` as this was already possible with current js exposed api's. This has just cut down the number of js->c++ call transitions. I feel `getNumDisplays` is a good to have api.  