### PR TITLE
Restore window state when showing window

### DIFF
--- a/atom/browser/native_window_views.cc
+++ b/atom/browser/native_window_views.cc
@@ -307,7 +307,7 @@ bool NativeWindowViews::IsFocused() {
 }
 
 void NativeWindowViews::Show() {
-  window_->Show();
+  window_->native_widget_private()->ShowWithWindowState(GetRestoredState());
 }
 
 void NativeWindowViews::ShowInactive() {
@@ -925,6 +925,15 @@ gfx::Rect NativeWindowViews::ContentBoundsToWindowBounds(
   if (menu_bar_ && menu_bar_visible_)
     window_bounds.set_height(window_bounds.height() + kMenuBarHeight);
   return window_bounds;
+}
+
+ui::WindowShowState NativeWindowViews::GetRestoredState() {
+  if (IsMaximized())
+    return ui::SHOW_STATE_MAXIMIZED;
+  if (IsFullscreen())
+    return ui::SHOW_STATE_FULLSCREEN;
+
+  return ui::SHOW_STATE_NORMAL;
 }
 
 // static

--- a/atom/browser/native_window_views.h
+++ b/atom/browser/native_window_views.h
@@ -141,6 +141,9 @@ class NativeWindowViews : public NativeWindow,
   // in client area we need to substract/add menu bar's height in convertions.
   gfx::Rect ContentBoundsToWindowBounds(const gfx::Rect& content_bounds);
 
+  // Returns the restore state for the window.
+  ui::WindowShowState GetRestoredState();
+
   scoped_ptr<views::Widget> window_;
   views::View* web_view_;  // Managed by inspectable_web_contents_.
 


### PR DESCRIPTION
This PR makes `BrowserWindow.show` restore previous window state. It only restores maximized and fullscreen state, for Aero Snap I couldn't find any API to determine whether window is in Aero Snap state, and there is no API to restore the Aero Snap state too, I doubt there is no way to do that.

Closes #1194.