### PR TITLE
shell: return status for moveitemtotrash operation

### DIFF
--- a/atom/common/platform_util.h
+++ b/atom/common/platform_util.h
@@ -26,7 +26,7 @@ void OpenItem(const base::FilePath& full_path);
 void OpenExternal(const GURL& url);
 
 // Move a file to trash.
-void MoveItemToTrash(const base::FilePath& full_path);
+bool MoveItemToTrash(const base::FilePath& full_path);
 
 void Beep();
 

--- a/atom/common/platform_util_mac.mm
+++ b/atom/common/platform_util_mac.mm
@@ -126,19 +126,21 @@ void OpenExternal(const GURL& url) {
     LOG(WARNING) << "NSWorkspace failed to open URL " << url;
 }
 
-void MoveItemToTrash(const base::FilePath& full_path) {
+bool MoveItemToTrash(const base::FilePath& full_path) {
   DCHECK([NSThread isMainThread]);
   NSString* path_string = base::SysUTF8ToNSString(full_path.value());
   NSArray* file_array =
       [NSArray arrayWithObject:[path_string lastPathComponent]];
-  if (!path_string || !file_array || ![[NSWorkspace sharedWorkspace]
-      performFileOperation:NSWorkspaceRecycleOperation
-                    source:[path_string stringByDeletingLastPathComponent]
-               destination:@""
-                     files:file_array
-                       tag:nil])
+  int status = [[NSWorkspace sharedWorkspace]
+                performFileOperation:NSWorkspaceRecycleOperation
+                source:[path_string stringByDeletingLastPathComponent]
+                destination:@""
+                files:file_array
+                tag:nil];
+  if (!path_string || !file_array || !status)
     LOG(WARNING) << "NSWorkspace failed to move file " << full_path.value()
                  << " to trash";
+  return (status == 0);
 }
 
 void Beep() {

--- a/docs/api/shell.md
+++ b/docs/api/shell.md
@@ -32,7 +32,7 @@ example, mailto: URLs in the default mail user agent.)
 
 * `fullPath` String
 
-Move the given file to trash.
+Move the given file to trash and returns boolean status for the operation.
 
 ## shell.beep()
 


### PR DESCRIPTION
Fixes #1014 , but any reason not use `base::DeleteFile` instead for all platforms ? 