### PR TITLE
Disable zygote process on Linux

### DIFF
--- a/script/lib/config.py
+++ b/script/lib/config.py
@@ -4,7 +4,7 @@ import platform
 import sys
 
 BASE_URL = 'http://gh-contractor-zcbenz.s3.amazonaws.com/libchromiumcontent'
-LIBCHROMIUMCONTENT_COMMIT = '26dd65a62e35aa98b25c10cbfc00f1a621fd4c4b'
+LIBCHROMIUMCONTENT_COMMIT = 'c01b10faf0d478e48f537210ec263fabd551578d'
 
 ARCH = {
     'cygwin': '32bit',


### PR DESCRIPTION
The zygote process has hijacked command line parameters and environment variables on Linux, making it hard to do some low level handling.

Fixes #1101.

This relies on patch https://github.com/atom/libchromiumcontent/blob/atom/patches/no_zygote.patch.