### PR TITLE
Ship d3dcompiler_47.dll

### DIFF
--- a/script/create-dist.py
+++ b/script/create-dist.py
@@ -32,7 +32,7 @@ TARGET_BINARIES = {
     'atom.exe',
     'chromiumcontent.dll',
     'content_shell.pak',
-    'd3dcompiler_46.dll',
+    'd3dcompiler_47.dll',
     'ffmpegsumo.dll',
     'icudtl.dat',
     'libEGL.dll',

--- a/script/update-external-binaries.py
+++ b/script/update-external-binaries.py
@@ -7,7 +7,7 @@ import os
 from lib.util import safe_mkdir, rm_rf, extract_zip, tempdir, download
 
 
-VERSION = 'v0.4.0'
+VERSION = 'v0.5.0'
 SOURCE_ROOT = os.path.abspath(os.path.dirname(os.path.dirname(__file__)))
 FRAMEWORKS_URL = 'http://github.com/atom/atom-shell-frameworks/releases' \
                  '/download/' + VERSION


### PR DESCRIPTION
From Chrome 41 `d3dcompiler_47.dll` is used to replace `d3dcompiler_46.dll`.

Fixes #1319.