### PR TITLE
Build node as shared library

### DIFF
--- a/atom.gyp
+++ b/atom.gyp
@@ -504,7 +504,6 @@
                 '<(libchromiumcontent_resources_dir)/ui_resources_200_percent.pak',
                 '<(libchromiumcontent_resources_dir)/natives_blob.bin',
                 '<(libchromiumcontent_resources_dir)/snapshot_blob.bin',
-                '<(PRODUCT_DIR)/node.dll',
                 'external_binaries/d3dcompiler_47.dll',
                 'external_binaries/msvcp120.dll',
                 'external_binaries/msvcr120.dll',
@@ -531,7 +530,6 @@
                 '<(libchromiumcontent_resources_dir)/content_shell.pak',
                 '<(libchromiumcontent_resources_dir)/natives_blob.bin',
                 '<(libchromiumcontent_resources_dir)/snapshot_blob.bin',
-                '<(PRODUCT_DIR)/libnode.so',
               ],
             },
             {

--- a/atom.gyp
+++ b/atom.gyp
@@ -973,7 +973,7 @@
             {
               'action_name': 'Create node.lib',
               'inputs': [
-                '<(PRODUCT_DIR)/<(project_name).lib',
+                '<(PRODUCT_DIR)/node.dll.lib',
                 '<(libchromiumcontent_library_dir)/chromiumcontent.dll.lib',
               ],
               'outputs': [

--- a/atom.gyp
+++ b/atom.gyp
@@ -504,6 +504,7 @@
                 '<(libchromiumcontent_resources_dir)/ui_resources_200_percent.pak',
                 '<(libchromiumcontent_resources_dir)/natives_blob.bin',
                 '<(libchromiumcontent_resources_dir)/snapshot_blob.bin',
+                '<(PRODUCT_DIR)/node.dll',
                 'external_binaries/d3dcompiler_47.dll',
                 'external_binaries/msvcp120.dll',
                 'external_binaries/msvcr120.dll',
@@ -530,6 +531,7 @@
                 '<(libchromiumcontent_resources_dir)/content_shell.pak',
                 '<(libchromiumcontent_resources_dir)/natives_blob.bin',
                 '<(libchromiumcontent_resources_dir)/snapshot_blob.bin',
+                '<(PRODUCT_DIR)/libnode.so',
               ],
             },
             {
@@ -548,7 +550,7 @@
       'dependencies': [
         'atom_coffee2c',
         'vendor/brightray/brightray.gyp:brightray',
-        'vendor/node/node.gyp:node_lib',
+        'vendor/node/node.gyp:node',
       ],
       'defines': [
         'PRODUCT_NAME="<(product_name)"',
@@ -866,9 +868,6 @@
           ],
           'xcode_settings': {
             'INFOPLIST_FILE': 'atom/common/resources/mac/Info.plist',
-            'LIBRARY_SEARCH_PATHS': [
-              '<(libchromiumcontent_library_dir)',
-            ],
             'LD_DYLIB_INSTALL_NAME': '@rpath/<(product_name) Framework.framework/<(product_name) Framework',
             'LD_RUNPATH_SEARCH_PATHS': [
               '@loader_path/Libraries',
@@ -883,6 +882,7 @@
               'files': [
                 '<(libchromiumcontent_library_dir)/ffmpegsumo.so',
                 '<(libchromiumcontent_library_dir)/libchromiumcontent.dylib',
+                '<(PRODUCT_DIR)/libnode.dylib',
               ],
             },
             {
@@ -894,6 +894,16 @@
             },
           ],
           'postbuilds': [
+            {
+              'postbuild_name': 'Fix path of libnode',
+              'action': [
+                'install_name_tool',
+                '-change',
+                '/usr/local/lib/libnode.dylib',
+                '@rpath/libnode.dylib',
+                '${BUILT_PRODUCTS_DIR}/<(product_name) Framework.framework/Versions/A/<(product_name) Framework',
+              ],
+            },
             {
               'postbuild_name': 'Add symlinks for framework subdirectories',
               'action': [

--- a/atom/common/node_bindings.cc
+++ b/atom/common/node_bindings.cc
@@ -32,29 +32,6 @@ void Init(int*, const char**, int*, const char***);
 #define REFERENCE_MODULE(name) \
   extern "C" void _register_ ## name(void); \
   void (*fp_register_ ## name)(void) = _register_ ## name
-// Node's builtin modules.
-REFERENCE_MODULE(cares_wrap);
-REFERENCE_MODULE(fs_event_wrap);
-REFERENCE_MODULE(buffer);
-REFERENCE_MODULE(contextify);
-REFERENCE_MODULE(crypto);
-REFERENCE_MODULE(fs);
-REFERENCE_MODULE(http_parser);
-REFERENCE_MODULE(os);
-REFERENCE_MODULE(v8);
-REFERENCE_MODULE(zlib);
-REFERENCE_MODULE(pipe_wrap);
-REFERENCE_MODULE(process_wrap);
-REFERENCE_MODULE(signal_wrap);
-REFERENCE_MODULE(smalloc);
-REFERENCE_MODULE(spawn_sync);
-REFERENCE_MODULE(tcp_wrap);
-REFERENCE_MODULE(timer_wrap);
-REFERENCE_MODULE(tls_wrap);
-REFERENCE_MODULE(tty_wrap);
-REFERENCE_MODULE(udp_wrap);
-REFERENCE_MODULE(uv);
-REFERENCE_MODULE(js_stream);
 // Atom Shell's builtin modules.
 REFERENCE_MODULE(atom_browser_app);
 REFERENCE_MODULE(atom_browser_auto_updater);

--- a/atom/common/node_bindings.cc
+++ b/atom/common/node_bindings.cc
@@ -22,11 +22,6 @@
 
 using content::BrowserThread;
 
-// Forward declaration of internal node functions.
-namespace node {
-void Init(int*, const char**, int*, const char***);
-}
-
 // Force all builtin modules to be referenced so they can actually run their
 // DSO constructors, see http://git.io/DRIqCg.
 #define REFERENCE_MODULE(name) \

--- a/atom/common/node_includes.h
+++ b/atom/common/node_includes.h
@@ -7,6 +7,8 @@
 
 // Include common headers for using node APIs.
 
+#define BUILDING_NODE_EXTENSION
+
 #undef ASSERT
 #undef CHECK
 #undef CHECK_EQ

--- a/common.gypi
+++ b/common.gypi
@@ -95,6 +95,8 @@
               '-Wno-unused-value',
               '-Wno-deprecated-declarations',
               '-Wno-return-type',
+              # Fix relocation error when compiling as shared library.
+              '-fPIC',
             ],
           }],
         ],

--- a/common.gypi
+++ b/common.gypi
@@ -1,4 +1,7 @@
 {
+  'includes': [
+    'vendor/brightray/brightray.gypi',
+  ],
   'variables': {
     'clang': 0,
     'openssl_no_asm': 1,
@@ -37,7 +40,7 @@
   # Settings to compile node under Windows.
   'target_defaults': {
     'target_conditions': [
-      ['_target_name in ["libuv", "http_parser", "cares", "openssl", "openssl-cli", "node_lib", "zlib"]', {
+      ['_target_name in ["libuv", "http_parser", "cares", "openssl", "openssl-cli", "node", "zlib"]', {
         'msvs_disabled_warnings': [
           4703,  # potentially uninitialized local pointer variable 'req' used
           4013,  # 'free' undefined; assuming extern returning int
@@ -96,9 +99,28 @@
           }],
         ],
       }],
-      ['_target_name in ["node_lib", "atom_lib"]', {
+      ['_target_name in ["node", "atom_lib"]', {
         'include_dirs': [
           'vendor/brightray/vendor/download/libchromiumcontent/src/v8/include',
+        ],
+      }],
+      ['_target_name=="node"', {
+        'conditions': [
+          ['OS=="linux"', {
+            'libraries': [
+              '<(libchromiumcontent_library_dir)/libchromiumcontent.so',
+            ],
+          }],
+          ['OS=="win"', {
+            'libraries': [
+              '<(libchromiumcontent_library_dir)/chromiumcontent.dll.lib',
+            ],
+          }],
+          ['OS=="mac"', {
+            'libraries': [
+              '<(libchromiumcontent_library_dir)/libchromiumcontent.dylib',
+            ],
+          }],
         ],
       }],
       ['_target_name=="libuv"', {

--- a/script/create-dist.py
+++ b/script/create-dist.py
@@ -33,6 +33,7 @@ TARGET_BINARIES = {
     'chromiumcontent.dll',
     'content_shell.pak',
     'd3dcompiler_47.dll',
+    'node.dll',
     'ffmpegsumo.dll',
     'icudtl.dat',
     'libEGL.dll',
@@ -49,6 +50,7 @@ TARGET_BINARIES = {
   'linux': [
     'atom',
     'content_shell.pak',
+    'libnode.so',
     'icudtl.dat',
     'libchromiumcontent.so',
     'libffmpegsumo.so',

--- a/script/update.py
+++ b/script/update.py
@@ -38,7 +38,7 @@ def update_gyp():
 
   ret = subprocess.call([python, gyp,
                          '-f', 'ninja', '--depth', '.', 'atom.gyp',
-                         '-Icommon.gypi', '-Ivendor/brightray/brightray.gypi',
+                         '-Icommon.gypi',
                          '-Dlinux_clang=0',  # Disable brightray's clang setting
                          '-Dtarget_arch={0}'.format(arch),
                          '-Dlibrary=static_library'])


### PR DESCRIPTION
This is our first step to #980.

We will change how we link with libchromiumcontent to be able to build 64bit binary on Windows. One problem is there are some conflicting symbols between Chromium and Node (namely NSS and OpenSSL), so we can not link libchromiumcontent and Node to the same binary. Previously we worked around it by building libchromiumcontent as shared library, since we are going to build it as static library, we have to build Node as shared library to work around the problem.