### PR TITLE
Update build-instructions-windows.md

### DIFF
--- a/docs/development/build-instructions-windows.md
+++ b/docs/development/build-instructions-windows.md
@@ -72,6 +72,10 @@ python script\test.py
 If you encountered an error like `Command xxxx not found`, you may try to use
 the `VS2012 Command Prompt` console to execute the build scripts.
 
+### Fatal internal compiler error: C1001
+
+Make sure you have the latest Visual Studio update installed.
+
 ### Assertion failed: ((handle))->activecnt >= 0
 
 If building under Cygwin, you may see `bootstrap.py` failed with following


### PR DESCRIPTION
In the troubleshooting section, include a recommendation to install the latest Visual Studio update if you run into a fatal internal compiler error while building. This resolved the fatal error (C1001) I was getting when trying to build.