### PR TITLE
webview: adding page-title-set event

### DIFF
--- a/atom/browser/api/atom_api_web_contents.cc
+++ b/atom/browser/api/atom_api_web_contents.cc
@@ -240,6 +240,11 @@ void WebContents::DidNavigateMainFrame(
     Emit("did-navigate-to-different-page");
 }
 
+void WebContents::TitleWasSet(content::NavigationEntry* entry,
+                              bool explicit_set) {
+  Emit("page-title-set", entry->GetTitle(), explicit_set);
+}
+
 bool WebContents::OnMessageReceived(const IPC::Message& message) {
   bool handled = true;
   IPC_BEGIN_MESSAGE_MAP(WebContents, message)

--- a/atom/browser/api/atom_api_web_contents.h
+++ b/atom/browser/api/atom_api_web_contents.h
@@ -172,6 +172,7 @@ class WebContents : public mate::EventEmitter,
   void WebContentsDestroyed() override;
   void NavigationEntryCommitted(
       const content::LoadCommittedDetails& load_details) override;
+  void TitleWasSet(content::NavigationEntry* entry, bool explicit_set) override;
 
   // content::BrowserPluginGuestDelegate:
   void DidAttach(int guest_proxy_routing_id) final;

--- a/atom/browser/lib/guest-view-manager.coffee
+++ b/atom/browser/lib/guest-view-manager.coffee
@@ -14,6 +14,7 @@ supportedWebViewEvents = [
   'close'
   'crashed'
   'destroyed'
+  'page-title-set'
 ]
 
 nextInstanceId = 0

--- a/atom/renderer/lib/web-view/guest-view-internal.coffee
+++ b/atom/renderer/lib/web-view/guest-view-internal.coffee
@@ -15,6 +15,7 @@ WEB_VIEW_EVENTS =
   'close': []
   'crashed': []
   'destroyed': []
+  'page-title-set': ['title', 'explicitSet']
 
 dispatchEvent = (webView, event, args...) ->
   throw new Error("Unkown event #{event}") unless WEB_VIEW_EVENTS[event]?

--- a/docs/api/web-view-tag.md
+++ b/docs/api/web-view-tag.md
@@ -310,6 +310,14 @@ Corresponds to the points in time when the spinner of the tab stops spinning.
 
 Fired when a redirect was received while requesting a resource.
 
+### page-title-set
+
+* `title` String
+* `explicitSet` Boolean
+
+Fired when page ttile is set during navigation. `explicitSet` is false when title is synthesised from file
+url.
+
 ### console-message
 
 * `level` Integer

--- a/spec/fixtures/pages/a.html
+++ b/spec/fixtures/pages/a.html
@@ -2,6 +2,7 @@
 <body>
 <script type="text/javascript" charset="utf-8">
   console.log('a');
+  document.title = "test"
 </script>
 </body>
 </html>

--- a/spec/webview-spec.coffee
+++ b/spec/webview-spec.coffee
@@ -142,3 +142,12 @@ describe '<webview> tag', ->
       webview.src = "file://#{fixtures}/pages/ipc-message.html"
       webview.setAttribute 'nodeintegration', 'on'
       document.body.appendChild webview
+
+  describe 'page-title-set event', ->
+    it 'emits when title is set', (done) ->
+      webview.addEventListener 'page-title-set', (e) ->
+        assert.equal e.title, 'test'
+        assert e.explicitSet
+        done()
+      webview.src = "file://#{fixtures}/pages/a.html"
+      document.body.appendChild webview


### PR DESCRIPTION
Fixes #1316 , currently we have worked around `getURL` to return the right value using [`setVirtualURL`](https://github.com/atom/atom-shell/blob/master/atom/browser/api/atom_api_web_contents.cc#L283) , this event will not be fired when there is no title explicitly set as it will shortcut [here](https://code.google.com/p/chromium/codesearch#chromium/src/content/browser/web_contents/web_contents_impl.cc&sq=package:chromium&rcl=1428204835&l=3408) since the value of final_title will be `blank` not the file name.  