### PR TITLE
Only install apm on tests

### DIFF
--- a/script/bootstrap.py
+++ b/script/bootstrap.py
@@ -33,8 +33,6 @@ def main():
   create_chrome_version_h()
   touch_config_gypi()
   update_atom_shell()
-  update_atom_modules('spec')
-
 
 def parse_args():
   parser = argparse.ArgumentParser(description='Bootstrap this project')
@@ -78,16 +76,6 @@ def update_node_modules(dirname):
       execute_stdout([NPM, 'install', '--verbose'])
     else:
       execute_stdout([NPM, 'install'])
-
-
-def update_atom_modules(dirname):
-  with scoped_cwd(dirname):
-    apm = os.path.join(SOURCE_ROOT, 'node_modules', '.bin', 'apm')
-    if sys.platform in ['win32', 'cygwin']:
-      apm = os.path.join(SOURCE_ROOT, 'node_modules', 'atom-package-manager',
-                         'bin', 'apm.cmd')
-    execute_stdout([apm, 'install'])
-
 
 def update_win32_python():
   with scoped_cwd(VENDOR_DIR):

--- a/script/test.py
+++ b/script/test.py
@@ -7,9 +7,17 @@ import sys
 
 SOURCE_ROOT = os.path.abspath(os.path.dirname(os.path.dirname(__file__)))
 
+def update_atom_modules(dirname):
+  with scoped_cwd(dirname):
+    apm = os.path.join(SOURCE_ROOT, 'node_modules', '.bin', 'apm')
+    if sys.platform in ['win32', 'cygwin']:
+      apm = os.path.join(SOURCE_ROOT, 'node_modules', 'atom-package-manager',
+                         'bin', 'apm.cmd')
+    execute_stdout([apm, 'install'])
 
 def main():
   os.chdir(SOURCE_ROOT)
+  update_atom_modules('spec')
 
   if sys.platform == 'darwin':
     atom_shell = os.path.join(SOURCE_ROOT, 'out', 'Debug', 'Atom.app',
@@ -20,7 +28,6 @@ def main():
     atom_shell = os.path.join(SOURCE_ROOT, 'out', 'Debug', 'atom')
 
   subprocess.check_call([atom_shell, 'spec'] + sys.argv[1:])
-
 
 if __name__ == '__main__':
   sys.exit(main())


### PR DESCRIPTION
This PR sets us up to only install apm when we're running the test suite. This gets us part of the way to supporting Node 0.12.x and io.js v1.6.3 for building Atom Shell, so that we don't have to pin building Atom Shell to whatever apm is compatible with. 

We still aren't completely compatible though, it appears that we're hitting incompatibilities with `chromium-pickle`:

```
C:\Users\Paul\code\atom\atom-shell\node_modules\asar\node_modules\chromium-pickle\node_modules\bindings\bindings.js:83
        throw e
              ^
Error: Module did not self-register.
    at Error (native)
    at Module.load (module.js:335:32)
    at Function.Module._load (module.js:290:12)
    at Module.require (module.js:345:17)
    at require (module.js:364:17)
    at bindings (C:\Users\Paul\code\atom\atom-shell\node_modules\asar\node_modules\chromium-pickle\node_modules\bindings
\bindings.js:76:44)
    at Object.<anonymous> (C:\Users\Paul\code\atom\atom-shell\node_modules\asar\node_modules\chromium-pickle\lib\main.js
:1:99)
    at Module._compile (module.js:410:26)
    at Object.Module._extensions..js (module.js:428:10)
    at Module.load (module.js:335:32)
```

## TODO:

- [ ] Fix completely borked code