### PR TITLE
Remove 'window-all-closed' callback function

### DIFF
--- a/docs/tutorial/quick-start.md
+++ b/docs/tutorial/quick-start.md
@@ -87,12 +87,6 @@ require('crash-reporter').start();
 // be closed automatically when the javascript object is GCed.
 var mainWindow = null;
 
-// Quit when all windows are closed.
-app.on('window-all-closed', function() {
-  if (process.platform != 'darwin')
-    app.quit();
-});
-
 // This method will be called when atom-shell has done everything
 // initialization and ready for creating browser windows.
 app.on('ready', function() {


### PR DESCRIPTION
See: https://github.com/atom/atom-shell/issues/1357

My observation is that the app.quit is triggered by default when all windows are closed.  And according to deepak1556's comment in aforementioned issue, the exception for darwin is no longer relevant.