### PR TITLE
webContents: event to detect status of requested resource

### DIFF
--- a/atom/browser/api/atom_api_web_contents.cc
+++ b/atom/browser/api/atom_api_web_contents.cc
@@ -224,6 +224,17 @@ void WebContents::DidStopLoading(content::RenderViewHost* render_view_host) {
   Emit("did-stop-loading");
 }
 
+void WebContents::DidGetResourceResponseStart(
+    const content::ResourceRequestDetails& details) {
+  Emit("did-get-response-details",
+       details.socket_address.IsEmpty(),
+       details.url,
+       details.original_url,
+       details.http_response_code,
+       details.method,
+       details.referrer);
+}
+
 void WebContents::DidGetRedirectForResourceRequest(
     content::RenderFrameHost* render_frame_host,
     const content::ResourceRedirectDetails& details) {

--- a/atom/browser/api/atom_api_web_contents.h
+++ b/atom/browser/api/atom_api_web_contents.h
@@ -161,6 +161,8 @@ class WebContents : public mate::EventEmitter,
                               const base::string16& error_description) override;
   void DidStartLoading(content::RenderViewHost* render_view_host) override;
   void DidStopLoading(content::RenderViewHost* render_view_host) override;
+  void DidGetResourceResponseStart(
+      const content::ResourceRequestDetails& details) override;
   void DidGetRedirectForResourceRequest(
       content::RenderFrameHost* render_frame_host,
       const content::ResourceRedirectDetails& details) override;

--- a/atom/browser/lib/guest-view-manager.coffee
+++ b/atom/browser/lib/guest-view-manager.coffee
@@ -8,6 +8,7 @@ supportedWebViewEvents = [
   'did-frame-finish-load'
   'did-start-loading'
   'did-stop-loading'
+  'did-get-response-details'
   'did-get-redirect-request'
   'console-message'
   'new-window'

--- a/atom/renderer/lib/web-view/guest-view-internal.coffee
+++ b/atom/renderer/lib/web-view/guest-view-internal.coffee
@@ -9,6 +9,8 @@ WEB_VIEW_EVENTS =
   'did-frame-finish-load': ['isMainFrame']
   'did-start-loading': []
   'did-stop-loading': []
+  'did-get-response-details': ['status', 'newUrl', 'originalUrl',
+                               'httpResponseCode', 'requestMethod', 'referrer']
   'did-get-redirect-request': ['oldUrl', 'newUrl', 'isMainFrame']
   'console-message': ['level', 'message', 'line', 'sourceId']
   'new-window': ['url', 'frameName', 'disposition']

--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -640,6 +640,19 @@ Corresponds to the points in time when the spinner of the tab starts spinning.
 
 Corresponds to the points in time when the spinner of the tab stops spinning.
 
+### Event: 'did-get-response-details'
+
+* `event` Event
+* `status` Boolean
+* `newUrl` String
+* `originalUrl` String
+* `httpResponseCode` Integer
+* `requestMethod` String
+* `referrer` String
+
+Emitted when details regarding a requested resource is available.
+`status` indicates the socket connection to download the resource.
+
 ### Event: 'did-get-redirect-request'
 
 * `event` Event

--- a/docs/api/web-view-tag.md
+++ b/docs/api/web-view-tag.md
@@ -302,6 +302,18 @@ Corresponds to the points in time when the spinner of the tab starts spinning.
 
 Corresponds to the points in time when the spinner of the tab stops spinning.
 
+### did-get-response-details
+
+* `status` Boolean
+* `newUrl` String
+* `originalUrl` String
+* `httpResponseCode` Integer
+* `requestMethod` String
+* `referrer` String
+
+Fired when details regarding a requested resource is available.
+`status` indicates socket connection to download the resource.
+
 ### did-get-redirect-request
 
 * `oldUrl` String

--- a/spec/api-browser-window-spec.coffee
+++ b/spec/api-browser-window-spec.coffee
@@ -221,3 +221,11 @@ describe 'browser-window module', ->
         assert.equal url, 'https://www.github.com/'
         done()
       w.loadUrl "file://#{fixtures}/pages/will-navigate.html"
+
+  describe 'did-get-response-details', ->
+    it 'emits when user requests a resource', (done) ->
+      w.webContents.on 'did-get-response-details', (event, status, url) ->
+        assert.notEqual status
+        assert.equal url, "https://d4hwcs1zqtwzs.cloudfront.net/mac/GitHub%20for%20Mac%20204.zip"
+        done()
+      w.loadUrl "https://central.github.com/mac/latest"


### PR DESCRIPTION
#1253 , can probably be fixed with this event. Also if needed can give `resource_type` as payload from the list [here](https://code.google.com/p/chromium/codesearch#chromium/src/content/public/common/resource_type.h&cl=GROK&ct=xref_jump_to_def&l=13&gsn=ResourceType) , some ugly switch case on coffee side will do. any thoughts ?